### PR TITLE
Ldap improvements

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -269,13 +269,13 @@ func (c *ApiController) SyncLdapUsers() {
 		return
 	}
 
+	exist, failed, _ := object.SyncLdapUsers(owner, users, ldapId)
+
 	err = object.UpdateLdapSyncTime(ldapId)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
-
-	exist, failed, _ := object.SyncLdapUsers(owner, users, ldapId)
 
 	c.ResponseOk(&LdapSyncResp{
 		Exist:  exist,


### PR DESCRIPTION
Make some improvements for LDAP work:
* update ldap sync time after synchronization is finished, not before
* when ldap autosync is enabled, first synchronization will be straightaway after adding/updating ldap settings, not after first timeout