### PR TITLE
fix: update user policy only if groups,name, owner updated

### DIFF
--- a/object/user.go
+++ b/object/user.go
@@ -603,9 +603,12 @@ func updateUser(id string, user *User, columns []string) (int64, error) {
 		return 0, err
 	}
 
-	if affected != 0 && ((util.InSlice(columns, "groups") && !slices.Equal(oldUser.Groups, user.Groups)) ||
+	hasImpactOnPolicy := 
+		(util.InSlice(columns, "groups") && !slices.Equal(oldUser.Groups, user.Groups)) ||
 		(util.InSlice(columns, "name") && oldUser.Name != user.Name) ||
-		(util.InSlice(columns, "owner") && oldUser.Owner != user.Owner)) {
+		(util.InSlice(columns, "owner") && oldUser.Owner != user.Owner)
+
+	if affected != 0 && hasImpactOnPolicy {
 		oldReachablePermissions, err := reachablePermissionsByUser(oldUser)
 		if err != nil {
 			return 0, fmt.Errorf("reachablePermissionsByUser: %w", err)

--- a/object/user.go
+++ b/object/user.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -597,17 +598,19 @@ func updateUser(id string, user *User, columns []string) (int64, error) {
 		return 0, err
 	}
 
-	oldReachablePermissions, err := reachablePermissionsByUser(oldUser)
-	if err != nil {
-		return 0, fmt.Errorf("reachablePermissionsByUser: %w", err)
-	}
-
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).Cols(columns...).Update(user)
 	if err != nil {
 		return 0, err
 	}
 
-	if affected != 0 {
+	if affected != 0 && ((util.InSlice(columns, "groups") && !slices.Equal(oldUser.Groups, user.Groups)) ||
+		(util.InSlice(columns, "name") && oldUser.Name != user.Name) ||
+		(util.InSlice(columns, "owner") && oldUser.Owner != user.Owner)) {
+		oldReachablePermissions, err := reachablePermissionsByUser(oldUser)
+		if err != nil {
+			return 0, fmt.Errorf("reachablePermissionsByUser: %w", err)
+		}
+
 		reachablePermissions, err := reachablePermissionsByUser(user)
 		if err != nil {
 			return 0, fmt.Errorf("reachablePermissionsByUser: %w", err)
@@ -659,17 +662,18 @@ func UpdateUserForAllFields(id string, user *User) (bool, error) {
 		return false, err
 	}
 
-	oldReachablePermissions, err := reachablePermissionsByUser(oldUser)
-	if err != nil {
-		return false, fmt.Errorf("reachablePermissionsByUser: %w", err)
-	}
-
 	affected, err := ormer.Engine.ID(core.PK{owner, name}).AllCols().Update(user)
 	if err != nil {
 		return false, err
 	}
 
-	if affected != 0 {
+	if affected != 0 &&
+		(!slices.Equal(oldUser.Groups, user.Groups) || oldUser.Owner != user.Owner || oldUser.Name != user.Name) {
+		oldReachablePermissions, err := reachablePermissionsByUser(oldUser)
+		if err != nil {
+			return false, fmt.Errorf("reachablePermissionsByUser: %w", err)
+		}
+
 		reachablePermissions, err := reachablePermissionsByUser(user)
 		if err != nil {
 			return false, fmt.Errorf("reachablePermissionsByUser: %w", err)


### PR DESCRIPTION
now policy mapper is called on every user login because last_signin_time updated. It is redundant.