### PR TITLE
fix: removed redundant checks in /test-ldap

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -295,7 +295,7 @@ func (c *ApiController) SyncLdapUsers() {
 func (c *ApiController) TestLdapConnection() {
 	var ldap object.Ldap
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &ldap)
-	if err != nil || util.IsStringsEmpty(ldap.Owner, ldap.ServerName, ldap.Host, ldap.Username, ldap.Password, ldap.BaseDn) {
+	if err != nil || util.IsStringsEmpty(ldap.Owner, ldap.Host, ldap.Username, ldap.Password, ldap.BaseDn) {
 		c.ResponseError(c.T("general:Missing parameter"))
 		return
 	}


### PR DESCRIPTION
removed redundant check for ldap server name in test-ldap route