### PR TITLE
fix: Correct migration condition in Migrator_1_198_0_PR_56

### DIFF
--- a/object/migrator_1_198_0_PR_56.go
+++ b/object/migrator_1_198_0_PR_56.go
@@ -38,7 +38,7 @@ func (*Migrator_1_198_0_PR_56) DoMigration() *migrate.Migration {
 		Migrate: func(engine *xorm.Engine) error {
 			dbType := engine.Dialect().URI().DBType
 
-			if dbType != schemas.POSTGRES || dbType != schemas.MYSQL {
+			if dbType != schemas.POSTGRES && dbType != schemas.MYSQL {
 				logs.Warn("You must make migration: 20240111IncreaseFieldsLenForUser manually")
 				return nil
 			}


### PR DESCRIPTION
This commit addresses an issue in the migration check condition of Migrator_1_198_0_PR_56. Previously, the condition used the logical OR operator instead of the logical AND operator, causing the migration to not be applied correctly. The correct condition now ensures that the migration is only applied when the database type is either POSTGRES or MYSQL