### PR TITLE
fix: add migration check for presence of 'password_change_required' column

### DIFF
--- a/object/migrator_1_287_0_PR_62.go
+++ b/object/migrator_1_287_0_PR_62.go
@@ -24,7 +24,21 @@ import (
 type Migrator_1_287_0_PR_62 struct{}
 
 func (*Migrator_1_287_0_PR_62) IsMigrationNeeded() bool {
-	return true
+    metas, err := ormer.Engine.DBMetas()
+    if err != nil {
+        return false
+    }
+    for _, meta := range metas {
+        if meta.Name == "user" {
+            for _, col := range meta.Columns() {
+                if col.Name == "password_change_required" {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+    return false
 }
 
 func (*Migrator_1_287_0_PR_62) DoMigration() *migrate.Migration {


### PR DESCRIPTION
Added a check to ensure the presence of the 'password_change_required' field in the user table structure. In a clean database scenario, this field may not exist initially, as it was not included in the description of the object.User structure. Originally, the field appeared in the table due to being added in the User structure description, causing xorm to include it in the table. However, in the new code, this field is no longer present in the structure. Nonetheless, a migration is applied that attempts to remove it, leading to a panic in the code.
