### PR TITLE
feat: generating keys only for jwt certificate scope

### DIFF
--- a/object/cert.go
+++ b/object/cert.go
@@ -199,7 +199,7 @@ func UpdateCert(id string, cert *Cert) (bool, error) {
 }
 
 func AddCert(cert *Cert) (bool, error) {
-	if cert.Certificate == "" || cert.PrivateKey == "" {
+	if cert.Scope == scopeCertJWT && (cert.Certificate == "" || cert.PrivateKey == "") {
 		certificate, privateKey := generateRsaKeys(cert.BitSize, cert.ExpireInYears, cert.Name, cert.Owner)
 		cert.Certificate = certificate
 		cert.PrivateKey = privateKey


### PR DESCRIPTION
this change fixes creation of certificates from api

before the change there was an error when trying to add ca certificate scoped cert with bitsize 0 and empty privateKey, this leaded to panic in cert.go AddCert method (the cause of the panic is zero given as bitSize parameter to the generateRsaKeys func)