### PR TITLE
feat: add min/max password length options to organization

### DIFF
--- a/controllers/organization.go
+++ b/controllers/organization.go
@@ -123,7 +123,7 @@ func (c *ApiController) UpdateOrganization() {
 		return
 	}
 
-	c.Data["json"] = wrapActionResponse(object.UpdateOrganization(c.Ctx.Request.Context(), id, &organization))
+	c.Data["json"] = wrapActionResponse(object.UpdateOrganization(c.Ctx.Request.Context(), id, &organization, c.GetAcceptLanguage()))
 	c.ServeJSON()
 }
 

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -586,7 +586,7 @@ func (c *ApiController) SetPassword() {
 		}
 	}
 
-	msg := object.CheckPasswordComplexity(targetUser, newPassword)
+	msg := object.CheckPasswordComplexity(targetUser, newPassword, c.GetAcceptLanguage())
 	if msg != "" {
 		c.ResponseUnprocessableEntity(msg)
 		return

--- a/i18n/locales/ar/data.json
+++ b/i18n/locales/ar/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/de/data.json
+++ b/i18n/locales/de/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Sie haben zu oft das falsche Passwort oder den falschen Code eingegeben. Bitte warten Sie %d Minuten und versuchen Sie es erneut",
     "Your region is not allow to signup by phone": "Ihre Region ist nicht berechtigt, sich telefonisch anzumelden",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "Nicht unterstützter Passworttyp: %s"
+    "unsupported password type: %s": "Nicht unterstützter Passworttyp: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Ungültiger Benutzername oder Passwort/Code",

--- a/i18n/locales/en/data.json
+++ b/i18n/locales/en/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/es/data.json
+++ b/i18n/locales/es/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Has ingresado la contraseña o código incorrecto demasiadas veces, por favor espera %d minutos e intenta de nuevo",
     "Your region is not allow to signup by phone": "Tu región no está permitida para registrarse por teléfono",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "Tipo de contraseña no compatible: %s"
+    "unsupported password type: %s": "Tipo de contraseña no compatible: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Nombre de usuario o contraseña/código no válido",

--- a/i18n/locales/fa/data.json
+++ b/i18n/locales/fa/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/fi/data.json
+++ b/i18n/locales/fi/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/fr/data.json
+++ b/i18n/locales/fr/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Vous avez entré le mauvais mot de passe ou code plusieurs fois, veuillez attendre %d minutes et réessayer",
     "Your region is not allow to signup by phone": "Votre région n'est pas autorisée à s'inscrire par téléphone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "Type de mot de passe non pris en charge : %s"
+    "unsupported password type: %s": "Type de mot de passe non pris en charge : %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Nom d'utilisateur ou mot de passe/code invalide",

--- a/i18n/locales/he/data.json
+++ b/i18n/locales/he/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/id/data.json
+++ b/i18n/locales/id/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Anda telah memasukkan kata sandi atau kode yang salah terlalu banyak kali, mohon tunggu selama %d menit dan coba lagi",
     "Your region is not allow to signup by phone": "Wilayah Anda tidak diizinkan untuk mendaftar melalui telepon",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "jenis sandi tidak didukung: %s"
+    "unsupported password type: %s": "jenis sandi tidak didukung: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/it/data.json
+++ b/i18n/locales/it/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ja/data.json
+++ b/i18n/locales/ja/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "あなたは間違ったパスワードまたはコードを何度も入力しました。%d 分間待ってから再度お試しください",
     "Your region is not allow to signup by phone": "あなたの地域は電話でサインアップすることができません",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "サポートされていないパスワードタイプ：%s"
+    "unsupported password type: %s": "サポートされていないパスワードタイプ：%s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/kk/data.json
+++ b/i18n/locales/kk/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ko/data.json
+++ b/i18n/locales/ko/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "올바르지 않은 비밀번호나 코드를 여러 번 입력했습니다. %d분 동안 기다리신 후 다시 시도해주세요",
     "Your region is not allow to signup by phone": "당신의 지역은 전화로 가입할 수 없습니다",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "지원되지 않는 암호 유형: %s"
+    "unsupported password type: %s": "지원되지 않는 암호 유형: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ms/data.json
+++ b/i18n/locales/ms/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/nl/data.json
+++ b/i18n/locales/nl/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/pl/data.json
+++ b/i18n/locales/pl/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/pt/data.json
+++ b/i18n/locales/pt/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ru/data.json
+++ b/i18n/locales/ru/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Вы ввели неправильный пароль или код слишком много раз, пожалуйста, подождите %d минут и попробуйте снова",
     "Your region is not allow to signup by phone": "Ваш регион не разрешает регистрацию по телефону",
     "password must not be same as previous": "пароль не должен быть такой же как предыдущий",
-    "unsupported password type: %s": "неподдерживаемый тип пароля: %s"
+    "unsupported password type: %s": "неподдерживаемый тип пароля: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Неправильное имя пользователя или пароль/код",

--- a/i18n/locales/sv/data.json
+++ b/i18n/locales/sv/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/tr/data.json
+++ b/i18n/locales/tr/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/uk/data.json
+++ b/i18n/locales/uk/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "You have entered the wrong password or code too many times, please wait for %d minutes and try again",
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "unsupported password type: %s"
+    "unsupported password type: %s": "unsupported password type: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/vi/data.json
+++ b/i18n/locales/vi/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "Bạn đã nhập sai mật khẩu hoặc mã quá nhiều lần, vui lòng đợi %d phút và thử lại",
     "Your region is not allow to signup by phone": "Vùng của bạn không được phép đăng ký bằng điện thoại",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "Loại mật khẩu không được hỗ trợ: %s"
+    "unsupported password type: %s": "Loại mật khẩu không được hỗ trợ: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/zh/data.json
+++ b/i18n/locales/zh/data.json
@@ -59,7 +59,8 @@
     "You have entered the wrong password or code too many times, please wait for %d minutes and try again": "密码错误次数已达上限，请在 %d 分后重试",
     "Your region is not allow to signup by phone": "所在地区不支持手机号注册",
     "password must not be same as previous": "password must not be same as previous",
-    "unsupported password type: %s": "不支持的密码类型: %s"
+    "unsupported password type: %s": "不支持的密码类型: %s",
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
   },
   "general": {
     "Invalid username or password/code": "用户名或密码无效",

--- a/init_data.json.template
+++ b/init_data.json.template
@@ -16,6 +16,8 @@
       "languages": ["en", "zh", "es", "fr", "de", "id", "ja", "ko", "ru", "vi", "it", "ms", "tr","ar", "he", "nl", "pl", "fi", "sv", "uk", "kk", "fa"],
       "masterPassword": "",
       "initScore": 2000,
+      "passwordMinLength: 1,
+      "passwordMaxLength": 100,
       "enableSoftDeletion": false,
       "isProfilePublic": true,
       "accountItems": []

--- a/object/check.go
+++ b/object/check.go
@@ -71,7 +71,7 @@ func CheckUserSignup(application *Application, organization *Organization, form 
 	}
 
 	if application.IsSignupItemVisible("Password") {
-		msg := CheckPasswordComplexityByOrg(organization, form.Password)
+		msg := CheckPasswordComplexityByOrg(organization, form.Password, lang)
 		if msg != "" {
 			return msg
 		}
@@ -229,14 +229,19 @@ func CheckOneTimePassword(user *User, dest, code, lang string) error {
 	return nil
 }
 
-func CheckPasswordComplexityByOrg(organization *Organization, password string) string {
-	errorMsg := checkPasswordComplexity(password, organization.PasswordOptions)
+func CheckPasswordComplexityByOrg(organization *Organization, password string, lang string) string {
+	maxLen := organization.PasswordMaxLength
+	minLen := organization.PasswordMinLength
+	if maxLen < len(password) || len(password) < minLen {
+		return fmt.Sprintf(i18n.Translate(lang, "check:The password must be between %d and %d characters long"), minLen, maxLen)
+	}
+		errorMsg := checkPasswordComplexity(password, organization.PasswordOptions)
 	return errorMsg
 }
 
-func CheckPasswordComplexity(user *User, password string) string {
+func CheckPasswordComplexity(user *User, password string, lang string) string {
 	organization, _ := GetOrganizationByUser(user)
-	return CheckPasswordComplexityByOrg(organization, password)
+	return CheckPasswordComplexityByOrg(organization, password, lang)
 }
 
 func checkLdapUserPassword(user *User, password string, lang string) error {

--- a/object/init.go
+++ b/object/init.go
@@ -92,6 +92,11 @@ func initBuiltInOrganization() bool {
 		return true
 	}
 
+	userTablePasswordMaxLength, err := GetUserTablePasswordMaxLength()
+	if err != nil {
+		panic(err)
+	}
+
 	organization = &Organization{
 		Owner:              "admin",
 		Name:               "built-in",
@@ -106,6 +111,8 @@ func initBuiltInOrganization() bool {
 		Tags:               []string{},
 		Languages:          []string{"en", "zh", "es", "fr", "de", "id", "ja", "ko", "ru", "vi", "pt"},
 		InitScore:          2000,
+		PasswordMaxLength:  userTablePasswordMaxLength,
+		PasswordMinLength:  1,
 		AccountItems:       getBuiltInAccountItems(),
 		EnableSoftDeletion: false,
 		IsProfilePublic:    false,

--- a/object/migrator.go
+++ b/object/migrator.go
@@ -33,6 +33,7 @@ func DoMigration() {
 		&Migrator_1_198_0_PR_56{},
 		&Migrator_1_287_0_PR_62{},
 		&Migrator_1_342_0_PR_94{},
+		&Migrator_1_19504_0_PR_105{},
 		// more migrators add here in chronological order...
 	}
 

--- a/object/migrator_1_19504_0_PR_105.go
+++ b/object/migrator_1_19504_0_PR_105.go
@@ -1,0 +1,69 @@
+package object
+
+import (
+	"github.com/beego/beego/logs"
+	"github.com/xorm-io/xorm"
+	"github.com/xorm-io/xorm/migrate"
+	"github.com/xorm-io/xorm/schemas"
+)
+
+type Migrator_1_19504_0_PR_105 struct{}
+
+func (*Migrator_1_19504_0_PR_105) IsMigrationNeeded() bool {
+	table, err := ormer.Engine.TableInfo(&Organization{})
+	if err != nil {
+		logs.Warn("Table 'organization' does not exist")
+		return false
+	}
+	for _, col := range table.Columns() {
+		if col.Name == "password_max_length" || col.Name == "password_min_length" {
+			return true
+		}
+	}
+	return false
+}
+
+func (*Migrator_1_19504_0_PR_105) DoMigration() *migrate.Migration {
+	migration := migrate.Migration{
+		ID: "20240314MigrateOrganization -- Set value for organization fields password_max_len/password_min_len",
+		Migrate: func(engine *xorm.Engine) error {
+			dbType := engine.Dialect().URI().DBType
+
+			if dbType != schemas.POSTGRES && dbType != schemas.MYSQL {
+				logs.Warn("You must make migration: Migrator_1_19504_0_PR_105 manually")
+				return nil
+			}
+
+			tx := engine.NewSession()
+			defer tx.Close()
+
+			err := tx.Begin()
+			if err != nil {
+				return err
+			}
+
+			organizations := []*Organization{}
+			err = tx.Table(new(Organization)).Where("password_max_length IS NULL AND password_min_length IS NULL").Find(&organizations)
+			if err != nil {
+				return err
+			}
+			maxLen, err := GetUserTablePasswordMaxLength()
+			if err != nil {
+				return err
+			}
+			for _, org := range organizations {
+				org.PasswordMaxLength = maxLen
+				org.PasswordMinLength = 1
+				_, err = tx.Where("owner = ? and name = ?", org.Owner, org.Name).
+					Cols("password_max_length", "password_min_length").
+					Update(org)
+				if err != nil {
+					return err
+				}
+			}
+			tx.Commit()
+			return nil
+		},
+	}
+	return &migration
+}

--- a/object/user.go
+++ b/object/user.go
@@ -38,6 +38,7 @@ const (
 const UserEnforcerId = "built-in/user-enforcer-built-in"
 
 var userEnforcer *UserGroupEnforcer
+var userMaxPasswordLength int
 
 func InitUserManager() {
 	enforcer, err := GetInitializedEnforcer(UserEnforcerId)
@@ -1212,4 +1213,22 @@ func GetUsersByTagWithFilter(owner string, tag string, cond builder.Cond) ([]*Us
 	}
 
 	return users, nil
+}
+
+func GetUserTablePasswordMaxLength() (int, error) {
+	if userMaxPasswordLength != 0 {
+		return userMaxPasswordLength, nil
+	}
+	user := User{}
+	table, err := ormer.Engine.TableInfo(&user)
+	if err != nil {
+		return 0, err
+	}
+	for _, col := range table.Columns() {
+		if col.Name == "password" {
+			userMaxPasswordLength = col.Length
+			return userMaxPasswordLength, nil
+		}
+	}
+	return 0, fmt.Errorf("could not found column 'password' in table 'user'")
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -6652,6 +6652,14 @@
                         "type": "string"
                     }
                 },
+                "passwordMinLength": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "passwordMaxLength": {
+                    "type": "integer",
+                    "format": "int64"
+                },
                 "passwordSalt": {
                     "type": "string"
                 },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -4368,6 +4368,12 @@ definitions:
         type: array
         items:
           type: string
+      passwordMinLength:
+        type: integer
+        format: int64
+      passwordMaxLength:
+        type: integer
+        format: int64
       passwordSalt:
         type: string
       passwordType:

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -223,6 +223,26 @@ class OrganizationEditPage extends React.Component {
         </Row>
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("organization:Password min length"), i18next.t("organization:Password min length - Tooltip"))} :
+          </Col>
+          <Col span={4} >
+            <InputNumber value={this.state.organization.passwordMinLength} onChange={value => {
+              this.updateOrganizationField("passwordMinLength", value);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
+            {Setting.getLabel(i18next.t("organization:Password max length"), i18next.t("organization:Password max length - Tooltip"))} :
+          </Col>
+          <Col span={4} >
+            <InputNumber value={this.state.organization.passwordMaxLength} onChange={value => {
+              this.updateOrganizationField("passwordMaxLength", value);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
             {Setting.getLabel(i18next.t("organization:Password change interval"), i18next.t("organization:Password change interval - Tooltip"))} :
           </Col>
           <Col span={4} >


### PR DESCRIPTION
The following changes have been made:

- Two fields, `password_min_length` and `password_max_length`, have been added to the organization entity.
- When creating a new organization, default values are assigned, where `password_max_length` is set to the maximum value of the `users.password` field, and `password_min_length` is set to 1.
- If an organization has already been created before these changes, the migration will set default values for it, just like when creating a new one.
- When editing an organization, for backward compatibility, if a third-party client is unaware of the new fields and does not include them in the request, default values will be assigned to `password_min_length` and `password_max_length` instead of returning an error.
- When editing a user's password, a check has been added to compare the new password with these two settings.
- New forms have been added to the organization's UI for filling in: "Password max length" and "Password min length".