### PR TITLE
feat: add "Password special chars" option to organization

### DIFF
--- a/i18n/locales/ar/data.json
+++ b/i18n/locales/ar/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/de/data.json
+++ b/i18n/locales/de/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Ihre Region ist nicht berechtigt, sich telefonisch anzumelden",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "Nicht unterstützter Passworttyp: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Ungültiger Benutzername oder Passwort/Code",

--- a/i18n/locales/en/data.json
+++ b/i18n/locales/en/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/es/data.json
+++ b/i18n/locales/es/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Tu región no está permitida para registrarse por teléfono",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "Tipo de contraseña no compatible: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Nombre de usuario o contraseña/código no válido",

--- a/i18n/locales/fa/data.json
+++ b/i18n/locales/fa/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/fi/data.json
+++ b/i18n/locales/fi/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/fr/data.json
+++ b/i18n/locales/fr/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Votre région n'est pas autorisée à s'inscrire par téléphone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "Type de mot de passe non pris en charge : %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Nom d'utilisateur ou mot de passe/code invalide",

--- a/i18n/locales/he/data.json
+++ b/i18n/locales/he/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/id/data.json
+++ b/i18n/locales/id/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Wilayah Anda tidak diizinkan untuk mendaftar melalui telepon",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "jenis sandi tidak didukung: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/it/data.json
+++ b/i18n/locales/it/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ja/data.json
+++ b/i18n/locales/ja/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "あなたの地域は電話でサインアップすることができません",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "サポートされていないパスワードタイプ：%s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/kk/data.json
+++ b/i18n/locales/kk/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ko/data.json
+++ b/i18n/locales/ko/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "당신의 지역은 전화로 가입할 수 없습니다",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "지원되지 않는 암호 유형: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ms/data.json
+++ b/i18n/locales/ms/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/nl/data.json
+++ b/i18n/locales/nl/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/pl/data.json
+++ b/i18n/locales/pl/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/pt/data.json
+++ b/i18n/locales/pt/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/ru/data.json
+++ b/i18n/locales/ru/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Ваш регион не разрешает регистрацию по телефону",
     "password must not be same as previous": "пароль не должен быть такой же как предыдущий",
     "unsupported password type: %s": "неподдерживаемый тип пароля: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Неправильное имя пользователя или пароль/код",

--- a/i18n/locales/sv/data.json
+++ b/i18n/locales/sv/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/tr/data.json
+++ b/i18n/locales/tr/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/uk/data.json
+++ b/i18n/locales/uk/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Your region is not allow to signup by phone",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "unsupported password type: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/vi/data.json
+++ b/i18n/locales/vi/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "Vùng của bạn không được phép đăng ký bằng điện thoại",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "Loại mật khẩu không được hỗ trợ: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "Invalid username or password/code",

--- a/i18n/locales/zh/data.json
+++ b/i18n/locales/zh/data.json
@@ -60,7 +60,8 @@
     "Your region is not allow to signup by phone": "所在地区不支持手机号注册",
     "password must not be same as previous": "password must not be same as previous",
     "unsupported password type: %s": "不支持的密码类型: %s",
-    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long"
+    "The password must be between %d and %d characters long": "The password must be between %d and %d characters long",
+    "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on": "You must fill 'Password special chars' if option 'The password must contain at least one special character' was set on"
   },
   "general": {
     "Invalid username or password/code": "用户名或密码无效",

--- a/object/check.go
+++ b/object/check.go
@@ -235,7 +235,7 @@ func CheckPasswordComplexityByOrg(organization *Organization, password string, l
 	if maxLen < len(password) || len(password) < minLen {
 		return fmt.Sprintf(i18n.Translate(lang, "check:The password must be between %d and %d characters long"), minLen, maxLen)
 	}
-		errorMsg := checkPasswordComplexity(password, organization.PasswordOptions)
+	errorMsg := checkPasswordComplexity(password, organization.PasswordOptions, organization.PasswordSpecialChars)
 	return errorMsg
 }
 
@@ -296,7 +296,6 @@ func checkLdapUserPassword(user *User, password string, lang string) error {
 	}
 	return resetUserSigninErrorTimes(user)
 }
-
 
 var ErrorUserNotFound = errors.New("user not found")
 var ErrorUserDeleted = errors.New("user deleted")

--- a/object/check_password_complexity_test.go
+++ b/object/check_password_complexity_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsValidOption_SpecialChar(t *testing.T) {
+func TestCheckPasswordComplexity_SpecialChar(t *testing.T) {
+	specialChars := `~!@#$%^&*_\-+=` + "`" + `|(){}[]:;"'<>,.?/😎`
 	for _, p := range []string{
 		"Passw0rd!@",
 		"!@Test123",
@@ -29,9 +30,10 @@ func TestIsValidOption_SpecialChar(t *testing.T) {
 		")",
 		"]",
 		"[",
+		"😎",
 	} {
 		t.Run("Password with special characters", func(t *testing.T) {
-			result := isValidOption_SpecialChar(p)
+			result := checkPasswordComplexity(p, []string{"SpecialChar"}, specialChars)
 			assert.True(t, len(result) == 0)
 		})
 	}
@@ -42,7 +44,7 @@ func TestIsValidOption_SpecialChar(t *testing.T) {
 		"TestPassword",
 	} {
 		t.Run("Password without special characters", func(t *testing.T) {
-			result := isValidOption_SpecialChar(p)
+			result := checkPasswordComplexity(p, []string{"SpecialChar"}, specialChars)
 			assert.True(t, len(result) > 0)
 		})
 	}

--- a/object/migrator.go
+++ b/object/migrator.go
@@ -34,6 +34,7 @@ func DoMigration() {
 		&Migrator_1_287_0_PR_62{},
 		&Migrator_1_342_0_PR_94{},
 		&Migrator_1_19504_0_PR_105{},
+		&Migrator_1_19503_0_PR_106{},
 		// more migrators add here in chronological order...
 	}
 

--- a/object/migrator_1_19503_0_PR_106.go
+++ b/object/migrator_1_19503_0_PR_106.go
@@ -1,0 +1,64 @@
+package object
+
+import (
+	"github.com/beego/beego/logs"
+	"github.com/xorm-io/xorm"
+	"github.com/xorm-io/xorm/migrate"
+	"github.com/xorm-io/xorm/schemas"
+)
+
+type Migrator_1_19503_0_PR_106 struct{}
+
+func (*Migrator_1_19503_0_PR_106) IsMigrationNeeded() bool {
+	table, err := ormer.Engine.TableInfo(&Organization{})
+	if err != nil {
+		logs.Warn("Table 'organization' does not exist")
+		return false
+	}
+	for _, col := range table.Columns() {
+		if col.Name == "password_special_chars" {
+			return true
+		}
+	}
+	return false
+}
+
+func (*Migrator_1_19503_0_PR_106) DoMigration() *migrate.Migration {
+	migration := migrate.Migration{
+		ID: "20240315MigrateOrganization -- Set value for organization field password_special_chars",
+		Migrate: func(engine *xorm.Engine) error {
+			dbType := engine.Dialect().URI().DBType
+
+			if dbType != schemas.POSTGRES && dbType != schemas.MYSQL {
+				logs.Warn("You must make migration: Migrator_1_19503_0_PR_106 manually")
+				return nil
+			}
+
+			tx := engine.NewSession()
+			defer tx.Close()
+
+			err := tx.Begin()
+			if err != nil {
+				return err
+			}
+
+			organizations := []*Organization{}
+			err = tx.Table(new(Organization)).Where("password_special_chars IS NULL").Find(&organizations)
+			if err != nil {
+				return err
+			}
+			for _, org := range organizations {
+				org.PasswordSpecialChars = DefaultOrganizationPasswordSpecialChars
+				_, err = tx.Where("owner = ? and name = ?", org.Owner, org.Name).
+					Cols("password_special_chars").
+					Update(org)
+				if err != nil {
+					return err
+				}
+			}
+			tx.Commit()
+			return nil
+		},
+	}
+	return &migration
+}

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -224,6 +224,19 @@ class OrganizationEditPage extends React.Component {
             />
           </Col>
         </Row>
+        <Row style={{marginTop: "20px", display: this.state.organization.passwordOptions.includes("SpecialChar") ? "" : "none"}}>
+          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+            {Setting.getLabel(i18next.t("organization:Password special chars"), i18next.t("organization:Password special chars - Tooltip"))} :
+          </Col>
+          <Col span={22}>
+            <Input
+              value={this.state.organization.passwordSpecialChars}
+              required={this.state.organization.passwordOptions.includes("SpecialChar")}
+              onChange={e => {
+                this.updateOrganizationField("passwordSpecialChars", e.target.value);
+              }} />
+          </Col>
+        </Row>
         <Row style={{marginTop: "20px"}} >
           <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 19 : 2}>
             {Setting.getLabel(i18next.t("organization:Password min length"), i18next.t("organization:Password min length - Tooltip"))} :

--- a/web/src/auth/ChangePasswordForm.js
+++ b/web/src/auth/ChangePasswordForm.js
@@ -113,7 +113,7 @@ export function ChangePasswordForm({application, userOwner, userName, onSuccess,
                 },
                 {
                   validator(rule, value) {
-                    const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions);
+                    const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions, application.organizationObj.passwordSpecialChars);
                     if (errorMsg === "") {
                       return Promise.resolve();
                     } else {

--- a/web/src/auth/ForgetPage.js
+++ b/web/src/auth/ForgetPage.js
@@ -401,7 +401,7 @@ class ForgetPage extends React.Component {
                   required: true,
                   validateTrigger: "onChange",
                   validator: (rule, value) => {
-                    const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions);
+                    const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions, application.organizationObj.passwordSpecialChars);
                     if (errorMsg === "") {
                       return Promise.resolve();
                     } else {

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -475,7 +475,7 @@ class SignupPage extends React.Component {
               required: required,
               validateTrigger: "onChange",
               validator: (rule, value) => {
-                const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions);
+                const errorMsg = PasswordChecker.checkPasswordComplexity(value, application.organizationObj.passwordOptions, application.organizationObj.passwordSpecialChars);
                 if (errorMsg === "") {
                   return Promise.resolve();
                 } else {

--- a/web/src/common/PasswordChecker.js
+++ b/web/src/common/PasswordChecker.js
@@ -36,12 +36,13 @@ function isValidOption_Aa123(password) {
   return "";
 }
 
-function isValidOption_SpecialChar(password) {
-  const regex = /^(?=.*[~!@#$%^&*_\-+=`|\\(){}[\]:;"'<>,.?/]).+$/;
-  if (!regex.test(password)) {
-    return i18next.t("user:The password must contain at least one special character");
+export function isValidOption_SpecialChar(password, specialChars) {
+  for (let i = 0; i < password.length; i++) {
+    if (specialChars.includes(password[i])) {
+      return "";
+    }
   }
-  return "";
+  return "The password must contain at least one special character";
 }
 
 function isValidOption_NoRepeat(password) {
@@ -76,7 +77,7 @@ function isValidOption_OneDigit(password) {
   return "";
 }
 
-export function checkPasswordComplexity(password, options) {
+export function checkPasswordComplexity(password, options, specialChars) {
   if (password.length === 0) {
     return i18next.t("login:Please input your password!");
   }
@@ -96,13 +97,20 @@ export function checkPasswordComplexity(password, options) {
     OneDigit: isValidOption_OneDigit,
   };
 
+  let errorMsg = "";
   for (const option of options) {
-    const checkerFunc = checkers[option];
-    if (checkerFunc) {
-      const errorMsg = checkerFunc(password);
-      if (errorMsg !== "") {
-        return errorMsg;
+    switch (option) {
+    case "SpecialChar":
+      errorMsg = isValidOption_SpecialChar(password, specialChars);
+      break;
+    default:
+      const checkerFunc = checkers[option];
+      if (checkerFunc) {
+        errorMsg = checkerFunc(password);
       }
+    }
+    if (errorMsg !== "") {
+      return errorMsg;
     }
   }
   return "";

--- a/web/src/common/modal/PasswordModal.js
+++ b/web/src/common/modal/PasswordModal.js
@@ -50,8 +50,8 @@ export const PasswordModal = (props) => {
   };
   const handleNewPassword = (value) => {
     setNewPassword(value);
-
-    const errorMessage = PasswordChecker.checkPasswordComplexity(value, passwordOptions);
+    const specialChars = organization ? organization.passwordSpecialChars : "";
+    const errorMessage = PasswordChecker.checkPasswordComplexity(value, passwordOptions, specialChars);
     setNewPasswordValid(errorMessage === "");
     setNewPasswordErrorMessage(errorMessage);
   };
@@ -84,7 +84,7 @@ export const PasswordModal = (props) => {
       return;
     }
 
-    const errorMsg = PasswordChecker.checkPasswordComplexity(newPassword, organization.passwordOptions);
+    const errorMsg = PasswordChecker.checkPasswordComplexity(newPassword, organization.passwordOptions, organization.passwordSpecialChars);
     if (errorMsg !== "") {
       Setting.showMessage("error", errorMsg);
       setConfirmLoading(false);


### PR DESCRIPTION
### Changes Made:
- Added a new field "PasswordSpecialChars" to the Organization entity.
- All existing organization records will default to the following value for the specified field: "~!@#$%^&*_-+=`|\(){}[]:;\"'<>,.?/"
- When creating a new organization, it will also be assigned the default value.
- The old check for SpecialChars, which validated the password when creating/updating a password using a regular expression, will now be based on the characters in "PasswordSpecialChars". This means that the client can now specify the necessary characters for the organization that need to be checked for the user.
- On the UI, to display the "Password special chars" field, you must first set the option "The password must contain at least one special character".
