### PR TITLE
feat: extend allowed symbols for username

### DIFF
--- a/object/check_username_test.go
+++ b/object/check_username_test.go
@@ -1,0 +1,40 @@
+package object
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckUsername(t *testing.T) {
+
+	for _, username := range []string{
+		strings.Repeat("a", 255),
+		"Admin",
+		"Admin.Admin",
+		"admin@mail.com",
+		"Admin111",
+		"123456789",
+		"A",
+		"a!#$%&'*+/=?^_`{|}~-@.z",
+	} {
+		t.Run("Valid usernames", func(t *testing.T) {
+			msg := CheckUsername(username, "en")
+			assert.True(t, len(msg) == 0)
+		})
+	}
+
+	for _, username := range []string{
+		"",
+		strings.Repeat("a", 256),
+		".Abc",
+		"123-",
+		"---",
+	} {
+		t.Run("Invalid usernames", func(t *testing.T) {
+			msg := CheckUsername(username, "en")
+			assert.True(t, len(msg) > 0)
+		})
+	}
+}

--- a/util/validation.go
+++ b/util/validation.go
@@ -22,6 +22,10 @@ import (
 	"github.com/nyaruka/phonenumbers"
 )
 
+const (
+	usernameAllowedSpecialSymbols = "!#$%&'*+/=?^{|}~@.\x60"
+)
+
 var (
 	rePhone          *regexp.Regexp
 	ReWhiteSpace     *regexp.Regexp
@@ -33,7 +37,9 @@ func init() {
 	rePhone, _ = regexp.Compile(`(\d{3})\d*(\d{4})`)
 	ReWhiteSpace, _ = regexp.Compile(`\s`)
 	ReFieldWhiteList, _ = regexp.Compile("^[`A-Za-z0-9]+$")
-	ReUserName, _ = regexp.Compile("^[a-zA-Z0-9]+((?:-[a-zA-Z0-9]+)|(?:_[a-zA-Z0-9]+))*$")
+
+	specialSymbolsPattern := regexp.QuoteMeta(usernameAllowedSpecialSymbols)
+	ReUserName, _ = regexp.Compile(fmt.Sprintf("^([a-zA-Z0-9]+[a-zA-Z0-9\\-_%s]*[a-zA-Z0-9]+|[a-zA-Z0-9]+)$", specialSymbolsPattern))
 }
 
 func IsEmailValid(email string) bool {


### PR DESCRIPTION
Add use of special symbols in username

List of special symbols: ```!#$%&'*+/=?^`{|}~@.```

Symbol are allowed in the middle of name along with underscores and hyphens. 
Start and finish symbol of the username must be alphanumeric.