### PR TITLE
fix: added handling of mapping invalid attributes when app is syncing…

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -464,7 +464,7 @@ func (c *ApiController) Login() {
 					record.AddReason(fmt.Sprintf("Login error: %s", err.Error()))
 				}
 				if user == nil {
-					_, err = object.SyncUserFromLdap(goCtx, authForm.Organization, authForm.LdapId, authForm.Username, authForm.Password, c.GetAcceptLanguage())
+					_, err = object.SyncUserFromLdap(goCtx, authForm.Organization, authForm.LdapId, authForm.Username, authForm.Password, c.GetAcceptLanguage(), record)
 					if err != nil {
 						record.AddReason(fmt.Sprintf("Ldap sync error: %s", err.Error()))
 					}

--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -87,7 +87,7 @@ func (c *ApiController) GetLdapUsers() {
 	//	})
 	//}
 
-	users, err := conn.GetLdapUsers(ldapServer, nil)
+	users, err := conn.GetLdapUsers(ldapServer, nil, record)
 	if err != nil {
 		record.AddReason(fmt.Sprintf("Get LDAP users: %s", err.Error()))
 

--- a/object/ldap_attribute_mapping.go
+++ b/object/ldap_attribute_mapping.go
@@ -1,10 +1,8 @@
 package object
 
 import (
-	"fmt"
 	"github.com/casdoor/casdoor/util"
 	goldap "github.com/go-ldap/ldap/v3"
-	"strings"
 )
 
 type (
@@ -41,7 +39,7 @@ func buildAttributeMappingMap(attributeMappingItems []*AttributeMappingItem) Att
 	return attributeMappingMap
 }
 
-func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMap AttributeMappingMap, rb *RecordBuilder) {
+func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMap AttributeMappingMap) []string {
 	unmappedAttributes := make([]string, 0)
 
 	// creating map for quick access to LDAP attributes by name
@@ -77,8 +75,5 @@ func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMa
 		}
 	}
 
-	// if there are unmapped attributes, log them
-	if len(unmappedAttributes) > 0 {
-		rb.AddReason(fmt.Sprintf("User (%s) has unmapped attributes: %s", entry.DN, strings.Join(unmappedAttributes, ", ")))
-	}
+	return unmappedAttributes
 }

--- a/object/ldap_attribute_mapping.go
+++ b/object/ldap_attribute_mapping.go
@@ -1,8 +1,10 @@
 package object
 
 import (
+	"fmt"
 	"github.com/casdoor/casdoor/util"
 	goldap "github.com/go-ldap/ldap/v3"
+	"strings"
 )
 
 type (
@@ -39,30 +41,44 @@ func buildAttributeMappingMap(attributeMappingItems []*AttributeMappingItem) Att
 	return attributeMappingMap
 }
 
-func MapAttributeToUser(attribute *goldap.EntryAttribute, user *LdapUser, attributeMappingMap AttributeMappingMap) {
-	if attributeMappingMap == nil {
-		return
+func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMap AttributeMappingMap, rb *RecordBuilder) {
+	unmappedAttributes := make([]string, 0)
+
+	// creating map for quick access to LDAP attributes by name
+	ldapAttributes := make(map[string]*goldap.EntryAttribute)
+	for _, attribute := range entry.Attributes {
+		ldapAttributes[attribute.Name] = attribute
 	}
 
-	if attribute == nil {
-		return
-	}
-
-	userFields := attributeMappingMap[AttributeMappingAttribute(attribute.Name)]
-	attributeValue := attribute.Values[0]
-
-	for _, userField := range userFields {
-		switch userField {
-		case "uid":
-			user.Uid = util.TruncateIfTooLong(attributeValue, 100)
-		case "email":
-			user.Email = util.TruncateIfTooLong(attributeValue, 100)
-		case "displayName":
-			user.Cn = util.TruncateIfTooLong(attributeValue, 100)
-		case "Phone":
-			user.MobileTelephoneNumber = util.TruncateIfTooLong(attributeValue, 20)
-		case "Address":
-			user.Address = attributeValue
+	// iterating over expected attributes from attributeMappingMap
+	for mappingAttr, userFields := range attributeMappingMap {
+		attribute, ok := ldapAttributes[string(mappingAttr)]
+		if !ok {
+			// attribute from map was not found in LDAP, we add it to the list of unmapped
+			unmappedAttributes = append(unmappedAttributes, string(mappingAttr))
+			continue
 		}
+
+		// if attribute is found, process its values
+		attributeValue := attribute.Values[0] // take first value as specified in original function
+		for _, userField := range userFields {
+			switch userField {
+			case "uid":
+				user.Uid = util.TruncateIfTooLong(attributeValue, 100)
+			case "email":
+				user.Email = util.TruncateIfTooLong(attributeValue, 100)
+			case "displayName":
+				user.Cn = util.TruncateIfTooLong(attributeValue, 100)
+			case "Phone":
+				user.MobileTelephoneNumber = util.TruncateIfTooLong(attributeValue, 20)
+			case "Address":
+				user.Address = attributeValue
+			}
+		}
+	}
+
+	// if there are unmapped attributes, log them
+	if len(unmappedAttributes) > 0 {
+		rb.AddReason(fmt.Sprintf("User (%s) has unmapped attributes: %s", entry.DN, strings.Join(unmappedAttributes, ", ")))
 	}
 }

--- a/object/ldap_autosync.go
+++ b/object/ldap_autosync.go
@@ -123,7 +123,7 @@ func syncUsers(ctx context.Context, ldap *Ldap) error {
 		return nil
 	}
 
-	users, err := conn.GetLdapUsers(ldap, nil)
+	users, err := conn.GetLdapUsers(ldap, nil, rb)
 	if err != nil {
 		logAndAddRecord(fmt.Sprintf("autoSync failed for %s, error %s", ldap.Id, err), logs.LevelWarning, rb)
 		return nil

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -233,7 +233,10 @@ func (l *LdapConn) GetLdapUsers(ldapServer *Ldap, selectedUser *User, rb *Record
 		var user LdapUser
 
 		if ldapServer.EnableAttributeMapping {
-			MapAttributesToUser(entry, &user, attributeMappingMap, rb)
+			unmappedAttributes := MapAttributesToUser(entry, &user, attributeMappingMap)
+			if len(unmappedAttributes) > 0 {
+				rb.AddReason(fmt.Sprintf("User (%s) has unmapped attributes: %s", entry.DN, strings.Join(unmappedAttributes, ", ")))
+			}
 		}
 
 		for _, attribute := range entry.Attributes {


### PR DESCRIPTION
… with ldap

In the case of attribute mapping `ldapServer.EnableAttributeMapping == true`, I added logs about non-existent attributes