### PR TITLE
fix: added getting a password when testing ldap if ldap exists in the db

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -392,6 +392,15 @@ func (c *ApiController) TestLdapConnection() {
 		return
 	}
 
+	if ldap.Password == "***" {
+		pwdFromDB, err := object.GetLdapPassword(ldap)
+		if err != nil {
+			c.ResponseError(err.Error())
+		}
+
+		ldap.Password = pwdFromDB
+	}
+
 	for _, roleMappingItem := range ldap.RoleMappingItems {
 		if util.IsStringsEmpty(roleMappingItem.Attribute, roleMappingItem.Role) || len(roleMappingItem.Values) == 0 {
 			c.ResponseError(c.T("general:Missing parameter"))

--- a/object/ldap.go
+++ b/object/ldap.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"fmt"
 	"github.com/casdoor/casdoor/util"
 )
 
@@ -180,4 +181,24 @@ func DeleteLdap(ldap *Ldap) (bool, error) {
 	}
 
 	return affected != 0, nil
+}
+
+func GetLdapPassword(ldap Ldap) (string, error) {
+	ldapFromDB := Ldap{
+		Owner:    ldap.Owner,
+		Host:     ldap.Host,
+		Port:     ldap.Port,
+		Username: ldap.Username,
+	}
+
+	existed, err := ormer.Engine.Get(&ldapFromDB)
+	if err != nil {
+		return "", err
+	}
+
+	if !existed {
+		return "", fmt.Errorf("ldap does not exist")
+	}
+
+	return ldapFromDB.Password, nil
 }


### PR DESCRIPTION
in the `api/test-ldap` endpoint, if the password is `***`, added taking the password from the ldap server stored in the database