### PR TITLE
fix: moved GetProviderHttpClient to separated package

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -281,7 +281,12 @@ func setHttpClient(idProvider idp.IdProvider, providerInfo idp.ProviderInfo) err
 	if isProxyProviderType(providerInfo.Type) {
 		idProvider.SetHttpClient(proxy.ProxyHttpClient)
 	} else {
-		client, err := object.GetProviderHttpClient(providerInfo)
+		httpClientProvider := &object.HttpClientProvider{}
+		client, err := httpClientProvider.GetProviderHttpClient(util.ProviderInfo{
+			Cert:     providerInfo.Cert,
+			ConfURL:  providerInfo.ConfURL,
+			TokenURL: providerInfo.TokenURL,
+		})
 		if err != nil {
 			return err
 		}
@@ -625,7 +630,7 @@ func (c *ApiController) Login() {
 		} else if provider.Category == "OAuth" || provider.Category == "Web3" {
 			// OAuth
 			idpInfo := object.FromProviderToIdpInfo(c.Ctx, provider)
-			idProvider := idp.GetIdProvider(idpInfo, authForm.RedirectUri)
+			idProvider := idp.GetIdProvider(idpInfo, authForm.RedirectUri, &object.HttpClientProvider{})
 			if idProvider == nil {
 				record.AddReason(fmt.Sprintf("Login error: provider type is not supported: %s", provider.Type))
 

--- a/controllers/provider.go
+++ b/controllers/provider.go
@@ -301,7 +301,7 @@ func (c *ApiController) TestProviderConnection() {
 		return
 	}
 	idpInfo := object.FromProviderToIdpInfo(nil, &provider)
-	idProvider := idp.GetIdProvider(idpInfo, idpInfo.RedirectUrl)
+	idProvider := idp.GetIdProvider(idpInfo, idpInfo.RedirectUrl, &object.HttpClientProvider{})
 
 	err = idProvider.TestConnection()
 	if err != nil {

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -15,6 +15,7 @@
 package idp
 
 import (
+	"github.com/casdoor/casdoor/util"
 	"net/http"
 	"strings"
 
@@ -65,7 +66,7 @@ func (b *BaseProvider) TestConnection() error {
 	return NewNotImplementedError("Not implemented")
 }
 
-func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) IdProvider {
+func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string, httpClientProvider util.HttpClientProvider) IdProvider {
 	switch idpInfo.Type {
 	case "GitHub":
 		return NewGithubIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl)
@@ -106,7 +107,7 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) IdProvider {
 	case "Custom":
 		return NewCustomIdProvider(idpInfo, redirectUrl)
 	case "OpenID":
-		return NewOpenIdProvider(idpInfo, redirectUrl)
+		return NewOpenIdProvider(idpInfo, redirectUrl, httpClientProvider)
 	case "Infoflow":
 		if idpInfo.SubType == "Internal" {
 			return NewInfoflowInternalIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, idpInfo.AppId, redirectUrl)

--- a/object/application.go
+++ b/object/application.go
@@ -223,9 +223,14 @@ func extendApplicationWithProviders(ctx context.Context, application *Applicatio
 
 func updateOpenIDWithUrls(provider *Provider) error {
 	idpInfo := FromProviderToIdpInfo(nil, provider)
-	openIDProvider := idp.NewOpenIdProvider(idpInfo, idpInfo.RedirectUrl)
+	httpClientProvider := &HttpClientProvider{}
+	openIDProvider := idp.NewOpenIdProvider(idpInfo, idpInfo.RedirectUrl, httpClientProvider)
 
-	client, err := GetProviderHttpClient(*idpInfo)
+	client, err := httpClientProvider.GetProviderHttpClient(util.ProviderInfo{
+		Cert:     idpInfo.Cert,
+		TokenURL: idpInfo.TokenURL,
+		ConfURL:  idpInfo.ConfURL,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to GetProviderHttpClient for provider %s", provider.Name)
 	}

--- a/object/provider.go
+++ b/object/provider.go
@@ -463,13 +463,15 @@ func FromProviderToIdpInfo(bCtx *bCtx.Context, provider *Provider) *idp.Provider
 	return providerInfo
 }
 
-func GetProviderHttpClient(providerInfo idp.ProviderInfo) (*http.Client, error) {
+type HttpClientProvider struct{}
+
+func (cp *HttpClientProvider) GetProviderHttpClient(info util.ProviderInfo) (*http.Client, error) {
 	transport := http.Transport{}
 
-	if (strings.HasPrefix(providerInfo.ConfURL, "https://") ||
-		strings.HasPrefix(providerInfo.TokenURL, "https://")) &&
-		providerInfo.Cert != "" {
-		tlsConf, err := GetTlsConfigForCert(providerInfo.Cert)
+	if (strings.HasPrefix(info.ConfURL, "https://") ||
+		strings.HasPrefix(info.TokenURL, "https://")) &&
+		info.Cert != "" {
+		tlsConf, err := GetTlsConfigForCert(info.Cert)
 		if err != nil {
 			return nil, err
 		}

--- a/util/http_client_provider.go
+++ b/util/http_client_provider.go
@@ -1,0 +1,13 @@
+package util
+
+import "net/http"
+
+type ProviderInfo struct {
+	Cert     string
+	ConfURL  string
+	TokenURL string
+}
+
+type HttpClientProvider interface {
+	GetProviderHttpClient(info ProviderInfo) (*http.Client, error)
+}


### PR DESCRIPTION
I solved the problem of cyclic dependence by putting the functionality in a separate package as an interface, and left the implementation in object/provider

I have taken out only one function from this functionality, but I plan to complement the interface