### PR TITLE
fix: update sha-1 to sha-256 in GetSamlResponse func

### DIFF
--- a/object/saml_idp.go
+++ b/object/saml_idp.go
@@ -307,7 +307,7 @@ func GetSamlResponse(application *Application, user *User, samlRequest string, h
 		X509Certificate: certificate,
 	}
 	ctx := dsig.NewDefaultSigningContext(randomKeyStore)
-	ctx.Hash = crypto.SHA1
+	ctx.Hash = crypto.SHA256
 	//signedXML, err := ctx.SignEnvelopedLimix(samlResponse)
 	//if err != nil {
 	//	return "", "", fmt.Errorf("err: %s", err.Error())


### PR DESCRIPTION
replaced the use of sha-1 with sha-256 in object.GetSamlResponse()