### PR TITLE
feat: case insensitivity handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ server_linux_amd64
 
 # ignore config
 # conf/app.conf
+
+# vscode workspaces
+*.code-workspace

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -464,9 +464,12 @@ func (c *ApiController) Login() {
 					record.AddReason(fmt.Sprintf("Login error: %s", err.Error()))
 				}
 				if user == nil {
-					_, err = object.SyncUserFromLdap(goCtx, authForm.Organization, authForm.LdapId, authForm.Username, authForm.Password, c.GetAcceptLanguage(), record)
+					userFromLdap, err := object.SyncUserFromLdap(goCtx, authForm.Organization, authForm.LdapId, authForm.Username, authForm.Password, c.GetAcceptLanguage(), record)
 					if err != nil {
 						record.AddReason(fmt.Sprintf("Ldap sync error: %s", err.Error()))
+					}
+					if userFromLdap != nil {
+						authForm.Username = userFromLdap.Uid
 					}
 				}
 			}

--- a/object/ldap.go
+++ b/object/ldap.go
@@ -43,6 +43,8 @@ type Ldap struct {
 	EnableRoleMapping bool               `xorm:"bool" json:"enableRoleMapping"`
 	RoleMappingItems  []*RoleMappingItem `xorm:"text" json:"roleMappingItems"`
 
+	EnableCaseInsensitivity bool `xorm:"bool" json:"enableCaseInsensitivity"`
+
 	AutoSync int    `json:"autoSync"`
 	LastSync string `xorm:"varchar(100)" json:"lastSync"`
 
@@ -165,7 +167,7 @@ func UpdateLdap(ldap *Ldap) (bool, error) {
 
 	affected, err := ormer.Engine.ID(ldap.Id).Cols("owner", "server_name", "host", "cert",
 		"port", "enable_ssl", "username", "password", "base_dn", "filter", "filter_fields", "auto_sync",
-		"role_mapping_items", "enable_role_mapping", "attribute_mapping_items", "enable_attribute_mapping",
+		"role_mapping_items", "enable_case_insensitivity", "enable_role_mapping", "attribute_mapping_items", "enable_attribute_mapping",
 		"enable_cryptographic_auth", "client_cert").Update(ldap)
 	if err != nil {
 		return false, nil

--- a/object/ldap_attribute_mapping.go
+++ b/object/ldap_attribute_mapping.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"strings"
+
 	"github.com/casdoor/casdoor/util"
 	goldap "github.com/go-ldap/ldap/v3"
 )
@@ -20,14 +22,20 @@ func (a AttributeMappingMap) Keys() []string {
 	return keys
 }
 
-func buildAttributeMappingMap(attributeMappingItems []*AttributeMappingItem) AttributeMappingMap {
+func buildAttributeMappingMap(attributeMappingItems []*AttributeMappingItem, enableCaseInsesitivity bool) AttributeMappingMap {
 	attributeMappingMap := make(AttributeMappingMap)
 	for _, item := range attributeMappingItems {
 		if item.Attribute == "" || item.UserField == "" {
 			continue
 		}
 
-		itemAttribute := AttributeMappingAttribute(item.Attribute)
+		var itemAttribute AttributeMappingAttribute
+		if enableCaseInsesitivity {
+			itemAttribute = AttributeMappingAttribute(strings.ToLower(item.Attribute))
+		} else {
+			itemAttribute = AttributeMappingAttribute(item.Attribute)
+		}
+
 		itemUserField := AttributeMappingUserField(item.UserField)
 
 		if _, ok := attributeMappingMap[itemAttribute]; !ok {
@@ -39,14 +47,20 @@ func buildAttributeMappingMap(attributeMappingItems []*AttributeMappingItem) Att
 	return attributeMappingMap
 }
 
-func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMap AttributeMappingMap) []string {
+func MapAttributesToUser(entry *goldap.Entry, user *LdapUser, attributeMappingMap AttributeMappingMap, enableCaseInsensitivity bool) []string {
 	unmappedAttributes := make([]string, 0)
 
 	// creating map for quick access to LDAP attributes by name
 	ldapAttributes := make(map[string]*goldap.EntryAttribute)
 	for _, attribute := range entry.Attributes {
-		ldapAttributes[attribute.Name] = attribute
+		if enableCaseInsensitivity {
+			ldapAttributes[strings.ToLower(attribute.Name)] = attribute
+		} else {
+			ldapAttributes[attribute.Name] = attribute
+		}
+		
 	}
+	
 
 	// iterating over expected attributes from attributeMappingMap
 	for mappingAttr, userFields := range attributeMappingMap {

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -202,7 +202,7 @@ func (l *LdapConn) GetLdapUsers(ldapServer *Ldap, selectedUser *User, rb *Record
 
 	var attributeMappingMap AttributeMappingMap
 	if ldapServer.EnableAttributeMapping {
-		attributeMappingMap = buildAttributeMappingMap(ldapServer.AttributeMappingItems)
+		attributeMappingMap = buildAttributeMappingMap(ldapServer.AttributeMappingItems, ldapServer.EnableCaseInsensitivity)
 		SearchAttributes = append(SearchAttributes, attributeMappingMap.Keys()...)
 	}
 
@@ -233,7 +233,7 @@ func (l *LdapConn) GetLdapUsers(ldapServer *Ldap, selectedUser *User, rb *Record
 		var user LdapUser
 
 		if ldapServer.EnableAttributeMapping {
-			unmappedAttributes := MapAttributesToUser(entry, &user, attributeMappingMap)
+			unmappedAttributes := MapAttributesToUser(entry, &user, attributeMappingMap, ldapServer.EnableCaseInsensitivity)
 			if len(unmappedAttributes) > 0 {
 				rb.AddReason(fmt.Sprintf("User (%s) has unmapped attributes: %s", entry.DN, strings.Join(unmappedAttributes, ", ")))
 			}

--- a/object/ldap_conn.go
+++ b/object/ldap_conn.go
@@ -605,12 +605,7 @@ func SyncUserFromLdap(ctx context.Context, organization string, ldapId string, u
 		}
 
 		_, _, err = SyncLdapUsers(ctx, organization, AutoAdjustLdapUser(res), ldapServer.Id)
-
-		if ldapServer.EnableCaseInsensitivity {
-			return &res[0], err
-		}
-		
-		return nil, err
+		return &res[0], err
 	}
 
 	return nil, nil

--- a/object/ldap_role_mapping.go
+++ b/object/ldap_role_mapping.go
@@ -15,6 +15,8 @@
 package object
 
 import (
+	"strings"
+
 	"github.com/casdoor/casdoor/util"
 )
 
@@ -44,7 +46,7 @@ func (r RoleMappingItemRoles) StrRoles() []string {
 	return result
 }
 
-func buildRoleMappingMap(roleMappingItems []*RoleMappingItem) RoleMappingMap {
+func buildRoleMappingMap(roleMappingItems []*RoleMappingItem, enableCaseInsensitivity bool) RoleMappingMap {
 	roleMappingMap := make(RoleMappingMap)
 	for _, roleMappingItem := range roleMappingItems {
 		for _, roleMappingItemValue := range roleMappingItem.Values {
@@ -52,12 +54,24 @@ func buildRoleMappingMap(roleMappingItems []*RoleMappingItem) RoleMappingMap {
 				continue
 			}
 
-			roleMappingAttribute := RoleMappingAttribute(roleMappingItem.Attribute)
+			var roleMappingAttribute RoleMappingAttribute
+			if enableCaseInsensitivity {
+				roleMappingAttribute = RoleMappingAttribute(strings.ToLower(roleMappingItem.Attribute))
+			} else {
+				roleMappingAttribute = RoleMappingAttribute(roleMappingItem.Attribute)
+			}
+
 			if _, ok := roleMappingMap[roleMappingAttribute]; !ok {
 				roleMappingMap[roleMappingAttribute] = make(RoleMappingMapItem)
 			}
-
-			roleMappingValue := RoleMappingItemValue(roleMappingItemValue)
+			
+			var roleMappingValue RoleMappingItemValue
+			if enableCaseInsensitivity {
+				roleMappingValue = RoleMappingItemValue(strings.ToLower(roleMappingItemValue))
+			} else {
+				roleMappingValue = RoleMappingItemValue(roleMappingItemValue)
+			}
+			
 			if _, ok := roleMappingMap[roleMappingAttribute][roleMappingValue]; !ok {
 				roleMappingMap[roleMappingAttribute][roleMappingValue] = make([]RoleMappingItemRoleId, 0)
 			}

--- a/web/src/LdapEditPage.js
+++ b/web/src/LdapEditPage.js
@@ -315,6 +315,16 @@ class LdapEditPage extends React.Component {
         </Row>
         <Row style={{marginTop: "20px"}} >
           <Col style={{lineHeight: "32px", textAlign: "right", paddingRight: "25px"}} span={4}>
+            {Setting.getLabel(i18next.t("ldap:Enable Case Insensitivity"), i18next.t("ldap:Enable Case Insensitivity - Tooltip"))} :
+          </Col>
+          <Col span={20}>
+            <Switch checked={this.state.ldap.enableCaseInsensitivity} onChange={checked => {
+              this.updateLdapField("enableCaseInsensitivity", checked);
+            }} />
+          </Col>
+        </Row>
+        <Row style={{marginTop: "20px"}} >
+          <Col style={{lineHeight: "32px", textAlign: "right", paddingRight: "25px"}} span={4}>
             {Setting.getLabel(i18next.t("ldap:Enable Attribute Mapping"), i18next.t("ldap:Enable Attribute Mapping - Tooltip"))} :
           </Col>
           <Col span={20} >

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -419,6 +419,8 @@
     "Edit LDAP": "Изменить LDAP",
     "Enable Attribute Mapping": "Enable Attribute Mapping",
     "Enable Attribute Mapping - Tooltip": "Enable Attribute Mapping - Tooltip",
+    "Enable Case Insensitivity": "Включить регистронезависимость",
+    "Enable Case Insensitivity - Tooltip": "Следует ли включать регистронезависимость",
     "Enable Cryptographic Authentication": "Включить криптографическую аутентификацию",
     "Enable Cryptographic Authentication - Tooltip": "Следует ли включать криптографическую аутентификацию",
     "Enable Role Mapping": "Включить сопоставление ролей",


### PR DESCRIPTION
add checkbox to enable case-insensitivity

if this checkbox is true:
- attributes and roles are mapped **regardless of the input case**
- during the login via ldap, if we could not find such a login in the database, but we received a username from the AD server, but in a different register, then this **new username is replaced instead of the old one** for further login flow

more info in `ASP-514`