### PR TITLE
fix: add generating of ldap.id before CheckLdapExist()

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -214,6 +214,10 @@ func (c *ApiController) AddLdap() {
 		return
 	}
 
+	if len(ldap.Id) == 0 {
+		ldap.Id = util.GenerateId()
+	}
+
 	if ok, err := object.CheckLdapExist(&ldap); err != nil {
 		record.AddReason(fmt.Sprintf("Check LDAP exists: %v", err.Error()))
 

--- a/object/ldap.go
+++ b/object/ldap.go
@@ -73,12 +73,7 @@ func AddLdap(ldap *Ldap) (bool, error) {
 func CheckLdapExist(ldap *Ldap) (bool, error) {
 	var result []*Ldap
 	err := ormer.Engine.Find(&result, &Ldap{
-		Owner:    ldap.Owner,
-		Host:     ldap.Host,
-		Port:     ldap.Port,
-		Username: ldap.Username,
-		Password: ldap.Password,
-		BaseDn:   ldap.BaseDn,
+		Id: ldap.Id,
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
previously, it was not possible to create several ldap connections at once because checking for the existence of a connection was always based on the same fields which was default

this is fixed by moving the id generation