### PR TITLE
fix: add cancellation of LDAP connection on deletion of LDAP server

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -15,8 +15,10 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+
 	goldap "github.com/go-ldap/ldap/v3"
 
 	"github.com/casdoor/casdoor/object"
@@ -64,7 +66,7 @@ func (c *ApiController) GetLdapUsers() {
 		return
 	}
 
-	conn, err := ldapServer.GetLdapConn()
+	conn, err := ldapServer.GetLdapConn(context.Background())
 	if err != nil {
 		record.AddReason(fmt.Sprintf("Get LDAP connection: %s", err.Error()))
 
@@ -424,7 +426,7 @@ func (c *ApiController) TestLdapConnection() {
 	}
 
 	var connection *object.LdapConn
-	connection, err = ldap.GetLdapConn()
+	connection, err = ldap.GetLdapConn(context.Background())
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/object/check.go
+++ b/object/check.go
@@ -254,7 +254,7 @@ func CheckLdapUserPassword(user *User, password string, lang string) (string, er
 	userDisabled := false
 
 	for _, ldapServer := range ldaps {
-		conn, err := ldapServer.GetLdapConn()
+		conn, err := ldapServer.GetLdapConn(context.Background())
 		if err != nil {
 			continue
 		}

--- a/object/policy_mapper_test.go
+++ b/object/policy_mapper_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func benchmarkUpdateRole(N int64, b *testing.B) {
 			Owner: testOrgName,
 			Name:  fmt.Sprintf("user_test-%d", i),
 		}
-		_, err = AddUser(new_user)
+		_, err = AddUser(context.Background(), new_user)
 		if err != nil {
 			b.Errorf("AddUser: %s", err)
 		}
@@ -119,7 +120,7 @@ func benchmarkDeleteRoleFromPermission(N int64, b *testing.B) {
 			Owner: testOrgName,
 			Name:  fmt.Sprintf("user_test-%d", i),
 		}
-		_, err = AddUser(new_user)
+		_, err = AddUser(context.Background(), new_user)
 		if err != nil {
 			b.Errorf("AddUser: %s", err)
 		}


### PR DESCRIPTION
Previously, deletion requests for LDAP configurations with a non-zero Auto Sync time frequently hung indefinitely. In the current fix, cancellation of LDAP connection attempts on deletion of LDAP servers has been added, which ensures that hanging deletion requests are avoided