### PR TITLE
fix: add recordBuilder via init func

### DIFF
--- a/object/record_builder.go
+++ b/object/record_builder.go
@@ -126,7 +126,7 @@ func GetRecord(ctx goCtx.Context) *RecordBuilder {
 
 	logs.Error("extract record from context: %s", err.Error())
 
-	return &RecordBuilder{}
+	return NewRecordBuilder()
 }
 
 var (


### PR DESCRIPTION
Added retrieval of RecordBuilder using the initialization function NewRecordBuilder to prevent panic. Previously, a panic occurred in the AddReason function when the record was not initialized
```
/usr/local/go/src/runtime/panic.go:261
/usr/local/go/src/runtime/signal_unix.go:861
/go/src/casgate/object/record_builder.go:85
/go/src/casgate/object/application.go:212
/go/src/casgate/object/application.go:368
/go/src/casgate/object/token.go:256
/go/src/casgate/object/token.go:293
/go/src/casgate/controllers/auth.go:150
/go/src/casgate/controllers/auth.go:543
/usr/local/go/src/reflect/value.go:596
/usr/local/go/src/reflect/value.go:380
/go/pkg/mod/github.com/beego/beego@v1.12.12/router.go:897
/usr/local/go/src/net/http/server.go:2938
/usr/local/go/src/net/http/server.go:2009
/usr/local/go/src/runtime/asm_amd64.s:1650
```