### PR TITLE
fix: resolve registration via invitation with unhashed password

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -226,6 +226,7 @@ func (c *ApiController) Signup() {
 
 		user.Id = invitedUser.Id
 		user.Name = invitedUser.Name
+		user.PasswordType = invitedUser.PasswordType
 
 		columns := []string{"password", "type"}
 
@@ -247,6 +248,11 @@ func (c *ApiController) Signup() {
 
 		if application.IsSignupItemVisible("Country/Region") {
 			columns = append(columns, "region")
+		}
+
+		if err := user.UpdateUserPassword(organization); err != nil {
+			c.ResponseError(err.Error())
+			return
 		}
 
 		affected, err = object.UpdateUser(invitedUser.GetId(), user, columns, false)


### PR DESCRIPTION
Fixed the issue where a new user registering via invitation would be assigned an unhashed password if a password hashing algorithm was specified. Now, the password is hashed correctly