### PR TITLE
fix: handle provider lookup for non-admin orgs during login

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -594,10 +594,17 @@ func (c *ApiController) Login() {
 
 			c.ResponseError(c.T(err.Error()))
 		}
-
-		provider, err := object.GetProvider(util.GetId("admin", authForm.Provider))
+		
+		providerID := util.GetId(application.Organization, authForm.Provider)
+		provider, err := object.GetProvider(providerID)
 		if err != nil {
 			record.AddReason(fmt.Sprintf("Login error: %s", err.Error()))
+
+			c.ResponseInternalServerError("internal server error")
+			return
+		}
+		if provider == nil {
+			record.AddReason(fmt.Sprintf("Could not find provider with id: %s", providerID))
 
 			c.ResponseInternalServerError("internal server error")
 			return


### PR DESCRIPTION
Added a fix for an issue where logging in through a provider could cause a panic if the provider was not associated with the admin organization