### PR TITLE
fix: remove unsupported password type from edit page

### DIFF
--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -184,7 +184,7 @@ class OrganizationEditPage extends React.Component {
           </Col>
           <Col span={22} >
             <Select virtual={false} style={{width: "100%"}} value={this.state.organization.passwordType} onChange={(value => {this.updateOrganizationField("passwordType", value);})}
-              options={["plain", "salt", "md5-salt", "bcrypt", "pbkdf2-salt", "argon2id"].map(item => Setting.getOption(item, item))}
+              options={["plain", "salt", "md5-salt", "bcrypt", "argon2id"].map(item => Setting.getOption(item, item))}
             />
           </Col>
         </Row>


### PR DESCRIPTION
there was an option on the edit page to select a password type that backend does not support