### PR TITLE
fix: update tooltip text color

### DIFF
--- a/web/src/theme.js
+++ b/web/src/theme.js
@@ -82,7 +82,7 @@ export const appThemeComponents = {
   },
   Tooltip: {
     colorBgSpotlight: "rgb(206, 216, 235)",
-    colorTextLightSolid: "rgb(46, 58, 82)",
+    colorTextLightSolid: "rgb(255, 255, 255)",
     paddingSM: 16,
     fontSize: 13,
     colorText: "rgb(46, 58, 82)",


### PR DESCRIPTION
Tooltips are made more readable.

Before:
![Screenshot 2024-07-19 at 23 47 20](https://github.com/user-attachments/assets/c4b5c774-24fe-4ed6-a3da-dbc2ad5d602a)

After:
![Screenshot 2024-07-19 at 23 48 12](https://github.com/user-attachments/assets/ce4e93ef-d2aa-4b7e-8905-bf5cd8c6a3e2)
