### PR TITLE
LDAP filter fix

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -284,8 +284,32 @@ func CheckLdapUserPassword(user *User, password string, lang string, ldapId stri
 			continue
 		}
 
-		searchReq := goldap.NewSearchRequest(ldapServer.BaseDn, goldap.ScopeWholeSubtree, goldap.NeverDerefAliases,
-			0, 0, false, ldapServer.BuildAuthFilterString(user), []string{}, nil,
+		var filter string
+
+		if conn.IsAD {
+			filter = fmt.Sprintf(
+				"(|(&%s(sAMAccountName=%s))(&%s(userPrincipalName=%s)))",
+				ldapServer.Filter,
+				user.GetName(),
+				ldapServer.Filter,
+				user.GetName())
+		} else {
+			filter = fmt.Sprintf(
+				"(&%s(uid=%s))",
+				ldapServer.Filter,
+				user.GetName())
+		}
+
+		searchReq := goldap.NewSearchRequest(
+			ldapServer.BaseDn,
+			goldap.ScopeWholeSubtree,
+			goldap.NeverDerefAliases,
+			0,
+			0,
+			false,
+			filter,
+			[]string{},
+			nil,
 		)
 
 		searchResult, err := conn.Conn.Search(searchReq)

--- a/object/check.go
+++ b/object/check.go
@@ -287,12 +287,13 @@ func CheckLdapUserPassword(user *User, password string, lang string, ldapId stri
 		var filter string
 
 		if conn.IsAD {
+			userName := user.GetName()
 			filter = fmt.Sprintf(
 				"(|(&%s(sAMAccountName=%s))(&%s(userPrincipalName=%s)))",
 				ldapServer.Filter,
-				user.GetName(),
+				userName,
 				ldapServer.Filter,
-				user.GetName())
+				userName)
 		} else {
 			filter = fmt.Sprintf(
 				"(&%s(uid=%s))",


### PR DESCRIPTION
When searching for a user in AD, you need to take into account that the field names differ from the usual LDAP server.