### PR TITLE
ldap search filter fix

### DIFF
--- a/ldap_sync/connection.go
+++ b/ldap_sync/connection.go
@@ -302,7 +302,16 @@ func (l *LdapConn) GetUsersFromLDAP(
 
 func (ldap *Ldap) BuildAuthFilterString(user LdapRelatedUser) string {
 	if len(ldap.FilterFields) == 0 {
-		return fmt.Sprintf("(&%s(uid=%s))", ldap.Filter, user.GetName())
+		uidFieldName := "uid"
+		if len(ldap.AttributeMappingItems) > 0 {
+			for _, item := range ldap.AttributeMappingItems {
+				if item.UserField == "uid" {
+					uidFieldName = item.Attribute
+					break
+				}
+			}
+		}
+		return fmt.Sprintf("(&%s(%s=%s))", ldap.Filter, uidFieldName, user.GetName())
 	}
 
 	filter := fmt.Sprintf("(&%s(|", ldap.Filter)

--- a/object/check.go
+++ b/object/check.go
@@ -284,26 +284,8 @@ func CheckLdapUserPassword(user *User, password string, lang string, ldapId stri
 			continue
 		}
 
-		uidFieldName := "uid"
-		if len(ldapServer.AttributeMappingItems) > 0 {
-			for _, item := range ldapServer.AttributeMappingItems {
-				if item.UserField == "uid" {
-					uidFieldName = item.Attribute
-					break
-				}
-			}
-		}
-
-		searchReq := goldap.NewSearchRequest(
-			ldapServer.BaseDn,
-			goldap.ScopeWholeSubtree,
-			goldap.NeverDerefAliases,
-			0,
-			0,
-			false,
-			fmt.Sprintf("(&%s(%s=%s))", ldapServer.Filter, uidFieldName, user.GetName()),
-			[]string{},
-			nil,
+		searchReq := goldap.NewSearchRequest(ldapServer.BaseDn, goldap.ScopeWholeSubtree, goldap.NeverDerefAliases,
+			0, 0, false, ldapServer.BuildAuthFilterString(user), []string{}, nil,
 		)
 
 		searchResult, err := conn.Conn.Search(searchReq)


### PR DESCRIPTION
When searching for a user in AD, you need to take into account that the field names differ from the usual LDAP server.