### PR TITLE
fix: log correct org name

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -25,6 +25,7 @@ import (
 	"github.com/casdoor/casdoor/object"
 	"github.com/casdoor/casdoor/util"
 	"github.com/casdoor/casdoor/util/logger"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -298,32 +299,41 @@ func (c *ApiController) Logout() {
 	redirectUri := c.Input().Get("post_logout_redirect_uri")
 	state := c.Input().Get("state")
 
-	user := c.GetSessionUsername()
-	c.Ctx.Input.SetData("user", user)
+	userNameWithOrg := c.GetSessionUsername()
+	c.Ctx.Input.SetData("user", userNameWithOrg)
 
 	goCtx := c.getRequestCtx()
-	record := object.GetRecord(goCtx).WithUsername(user)
+	record := object.GetRecord(goCtx).WithUsername(userNameWithOrg)
 
 	logger.SetItem(goCtx, "obj-type", "application")
-	logger.SetItem(goCtx, "usr", user)
+	logger.SetItem(goCtx, "usr", userNameWithOrg)
 
 	if accessToken == "" && redirectUri == "" {
 		// TODO https://github.com/casdoor/casdoor/pull/1494#discussion_r1095675265
-		if user == "" {
+		if userNameWithOrg == "" {
 			c.ResponseOk()
 			return
 		}
-
-		logger.SetItem(goCtx, "obj", object.CasdoorApplication)
-
-		c.ClearUserSession()
-		owner, username, err := util.GetOwnerAndNameFromId(user)
+		owner, username, err := util.GetOwnerAndNameFromUsernameWithOrg(userNameWithOrg)
 		if err != nil {
 			record.AddReason(fmt.Sprintf("Logout error: %s", err.Error()))
 
 			c.ResponseError(err.Error())
 			return
 		}
+		application, err := object.GetApplicationByUserId(goCtx, userNameWithOrg)
+		if err != nil {
+			err = errors.Wrap(err, "Logout error: failed to get application for user")
+			logLogoutErr(goCtx, err.Error())
+			c.ResponseError(err.Error())
+			return
+		}
+		logger.SetItem(goCtx, "obj", object.CasdoorApplication)
+		if application != nil {
+			logger.SetItem(goCtx, "obj", application.GetId())
+		}
+
+		c.ClearUserSession()
 		_, err = object.DeleteSessionId(
 			goCtx,
 			util.GetSessionId(owner, username, object.CasdoorApplication),
@@ -335,31 +345,21 @@ func (c *ApiController) Logout() {
 			return
 		}
 
-		application := c.GetSessionApplication()
-
-		if application != nil {
-			logger.SetItem(goCtx, "obj", application.GetId())
-		}
 		logger.Info(goCtx,
 			"",
 			"act", "logout",
 			"r", "success",
 		)
 
-		if application == nil || application.Name == "app-built-in" || application.HomepageUrl == "" {
+		if application == nil || application.Name == object.CasdoorApplication || application.HomepageUrl == "" {
 			record.AddReason("Logout error: application mismatch")
 
-			c.ResponseOk(user)
+			c.ResponseOk(userNameWithOrg)
 			return
 		}
-		c.ResponseOk(user, application.HomepageUrl)
+		c.ResponseOk(userNameWithOrg, application.HomepageUrl)
 		return
 	} else {
-		// "post_logout_redirect_uri" has been made optional, see: https://github.com/casdoor/casdoor/issues/2151
-		// if redirectUri == "" {
-		// 	c.ResponseError(c.T("general:Missing parameter") + ": post_logout_redirect_uri")
-		// 	return
-		// }
 		if accessToken == "" {
 			logLogoutErr(goCtx, "Logout error: missing id_token_hint")
 			c.ResponseError(c.T("general:Missing parameter") + ": id_token_hint")
@@ -388,14 +388,14 @@ func (c *ApiController) Logout() {
 
 		logger.SetItem(goCtx, "obj", application.GetId())
 
-		if user == "" {
-			user = util.GetId(token.Organization, token.User)
-			logger.SetItem(goCtx, "usr", user)
+		if userNameWithOrg == "" {
+			userNameWithOrg = util.GetId(token.Organization, token.User)
+			logger.SetItem(goCtx, "usr", userNameWithOrg)
 		}
 
 		c.ClearUserSession()
 		// TODO https://github.com/casdoor/casdoor/pull/1494#discussion_r1095675265
-		owner, username, err := util.GetOwnerAndNameFromId(user)
+		owner, username, err := util.GetOwnerAndNameFromUsernameWithOrg(userNameWithOrg)
 		if err != nil {
 			record.AddReason(fmt.Sprintf("Logout error: %s", err.Error()))
 
@@ -411,13 +411,13 @@ func (c *ApiController) Logout() {
 			return
 		}
 
-		util.LogInfo(c.Ctx, "API: [%s] logged out", user)
+		util.LogInfo(c.Ctx, "API: [%s] logged out", userNameWithOrg)
 
 		if redirectUri == "" {
 			logger.Info(goCtx,
 				"",
 				"obj-type", "application",
-				"usr", user,
+				"usr", userNameWithOrg,
 				"obj", application.GetId(),
 				"act", "logout",
 				"r", "success",
@@ -429,7 +429,7 @@ func (c *ApiController) Logout() {
 				logger.Info(goCtx,
 					"",
 					"obj-type", "application",
-					"usr", user,
+					"usr", userNameWithOrg,
 					"obj", application.GetId(),
 					"act", "logout",
 					"r", "success",

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -314,7 +314,7 @@ func (c *ApiController) Logout() {
 			c.ResponseOk()
 			return
 		}
-		owner, username, err := util.GetOwnerAndNameFromUsernameWithOrg(userNameWithOrg)
+		owner, username, err := util.SplitIdIntoOrgAndName(userNameWithOrg)
 		if err != nil {
 			record.AddReason(fmt.Sprintf("Logout error: %s", err.Error()))
 
@@ -395,7 +395,7 @@ func (c *ApiController) Logout() {
 
 		c.ClearUserSession()
 		// TODO https://github.com/casdoor/casdoor/pull/1494#discussion_r1095675265
-		owner, username, err := util.GetOwnerAndNameFromUsernameWithOrg(userNameWithOrg)
+		owner, username, err := util.SplitIdIntoOrgAndName(userNameWithOrg)
 		if err != nil {
 			record.AddReason(fmt.Sprintf("Logout error: %s", err.Error()))
 

--- a/controllers/casbin_api.go
+++ b/controllers/casbin_api.go
@@ -75,7 +75,7 @@ func (c *ApiController) Enforce() {
 
 	permissions := []*object.Permission{}
 	if modelId != "" {
-		owner, modelName, err := util.GetOwnerAndNameFromId(modelId)
+		owner, modelName, err := util.GetOwnerAndNameFromUsernameWithOrg(modelId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
@@ -171,7 +171,7 @@ func (c *ApiController) BatchEnforce() {
 
 	permissions := []*object.Permission{}
 	if modelId != "" {
-		owner, modelName, err := util.GetOwnerAndNameFromId(modelId)
+		owner, modelName, err := util.GetOwnerAndNameFromUsernameWithOrg(modelId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return

--- a/controllers/casbin_api.go
+++ b/controllers/casbin_api.go
@@ -75,7 +75,7 @@ func (c *ApiController) Enforce() {
 
 	permissions := []*object.Permission{}
 	if modelId != "" {
-		owner, modelName, err := util.GetOwnerAndNameFromUsernameWithOrg(modelId)
+		owner, modelName, err := util.SplitIdIntoOrgAndName(modelId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
@@ -171,7 +171,7 @@ func (c *ApiController) BatchEnforce() {
 
 	permissions := []*object.Permission{}
 	if modelId != "" {
-		owner, modelName, err := util.GetOwnerAndNameFromUsernameWithOrg(modelId)
+		owner, modelName, err := util.SplitIdIntoOrgAndName(modelId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return

--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -409,7 +409,7 @@ func (c *ApiController) SyncLdapUsers() {
 	id := c.Input().Get("id")
 	logger.SetItem(goCtx, "obj", id)
 
-	_, ldapId, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	_, ldapId, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		record.AddReason(err.Error())
 		logger.Error(

--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -409,7 +409,7 @@ func (c *ApiController) SyncLdapUsers() {
 	id := c.Input().Get("id")
 	logger.SetItem(goCtx, "obj", id)
 
-	_, ldapId, err := util.GetOwnerAndNameFromId(id)
+	_, ldapId, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		record.AddReason(err.Error())
 		logger.Error(

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -196,7 +196,7 @@ func (c *ApiController) GetUser() {
 	id := util.GetId(user.Owner, user.Name)
 
 	if request.Owner == "" {
-		request.Owner, err = util.GetOwnerFromId(id)
+		request.Owner, _, err = util.SplitIdIntoOrgAndName(id)
 		if err != nil {
 			c.ResponseInternalServerError(err.Error())
 			return
@@ -242,7 +242,7 @@ func (c *ApiController) GetUser() {
 	}
 
 	if fillUserIdProvider {
-		owner, err := util.GetOwnerFromId(id)
+		owner, _, err := util.SplitIdIntoOrgAndName(id)
 		if err != nil {
 			c.ResponseInternalServerError(err.Error())
 			return

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1273,7 +1273,7 @@ func (c *ApiController) SendInvite() {
 		link = fmt.Sprintf("%s/signup/%s?id=%s&u=%s&e=%s", origin, application.Name, user.Id, user.Name, user.Email)
 	default:
 		switch {
-		case application.Name == "app-built-in":
+		case application.Name == object.CasdoorApplication:
 			link = fmt.Sprintf("%s/login?u=%s", origin, user.Name)
 		case application.SigninUrl != "":
 			link = application.SigninUrl

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -80,7 +80,7 @@ func getAdapter(owner, name string) (*Adapter, error) {
 }
 
 func GetAdapter(id string) (*Adapter, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func GetAdapter(id string) (*Adapter, error) {
 }
 
 func UpdateAdapter(id string, adapter *Adapter) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -80,7 +80,7 @@ func getAdapter(owner, name string) (*Adapter, error) {
 }
 
 func GetAdapter(id string) (*Adapter, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func GetAdapter(id string) (*Adapter, error) {
 }
 
 func UpdateAdapter(id string, adapter *Adapter) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/application.go
+++ b/object/application.go
@@ -353,7 +353,7 @@ func GetApplicationByUser(ctx context.Context, user *User) (*Application, error)
 }
 
 func GetApplicationByUserId(ctx context.Context, userId string) (application *Application, err error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(userId)
+	owner, name, err := util.SplitIdIntoOrgAndName(userId)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func GetApplicationByClientId(ctx context.Context, clientId string) (*Applicatio
 }
 
 func GetApplication(ctx context.Context, id string) (*Application, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func GetApplication(ctx context.Context, id string) (*Application, error) {
 }
 
 func GetApplicationWithOpts(ctx context.Context, id string, opts *GetApplicationOptions) (*Application, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func GetMaskedApplications(applications []*Application, userId string) []*Applic
 }
 
 func UpdateApplication(ctx context.Context, id string, application *Application) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/application.go
+++ b/object/application.go
@@ -353,7 +353,7 @@ func GetApplicationByUser(ctx context.Context, user *User) (*Application, error)
 }
 
 func GetApplicationByUserId(ctx context.Context, userId string) (application *Application, err error) {
-	owner, name, err := util.GetOwnerAndNameFromId(userId)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(userId)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func GetApplicationByClientId(ctx context.Context, clientId string) (*Applicatio
 }
 
 func GetApplication(ctx context.Context, id string) (*Application, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func GetApplication(ctx context.Context, id string) (*Application, error) {
 }
 
 func GetApplicationWithOpts(ctx context.Context, id string, opts *GetApplicationOptions) (*Application, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func GetMaskedApplications(applications []*Application, userId string) []*Applic
 }
 
 func UpdateApplication(ctx context.Context, id string, application *Application) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}
@@ -486,7 +486,7 @@ func UpdateApplication(ctx context.Context, id string, application *Application)
 		return false, err
 	}
 
-	if name == "app-built-in" {
+	if name == CasdoorApplication {
 		application.Name = name
 	}
 
@@ -617,7 +617,7 @@ func AddApplication(ctx context.Context, application *Application) (bool, error)
 }
 
 func DeleteApplication(application *Application) (bool, error) {
-	if application.Name == "app-built-in" {
+	if application.Name == CasdoorApplication {
 		return false, nil
 	}
 

--- a/object/cert.go
+++ b/object/cert.go
@@ -117,7 +117,7 @@ func getCert(owner string, name string) (*casdoorcert.Cert, error) {
 }
 
 func GetCert(id string) (*casdoorcert.Cert, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func GetCert(id string) (*casdoorcert.Cert, error) {
 }
 
 func UpdateCert(id string, cert *casdoorcert.Cert) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/cert.go
+++ b/object/cert.go
@@ -117,7 +117,7 @@ func getCert(owner string, name string) (*casdoorcert.Cert, error) {
 }
 
 func GetCert(id string) (*casdoorcert.Cert, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func GetCert(id string) (*casdoorcert.Cert, error) {
 }
 
 func UpdateCert(id string, cert *casdoorcert.Cert) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/check.go
+++ b/object/check.go
@@ -490,7 +490,7 @@ func CheckUserPermission(ctx context.Context, requestUserId, userId string, stri
 		return false, fmt.Errorf(i18n.Translate(lang, "general:Please login first"))
 	}
 
-	userOwner, err := util.GetOwnerFromId(userId)
+	userOwner, _, err := util.SplitIdIntoOrgAndName(userId)
 	if err != nil {
 		return false, err
 	}

--- a/object/domain.go
+++ b/object/domain.go
@@ -247,7 +247,7 @@ func domainChangeTrigger(oldName string, newName string) error {
 
 	for _, role := range roles {
 		for j, u := range role.Domains {
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -270,7 +270,7 @@ func domainChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}

--- a/object/domain.go
+++ b/object/domain.go
@@ -77,12 +77,12 @@ func getDomain(owner string, name string) (*Domain, error) {
 }
 
 func GetDomain(id string) (*Domain, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	return getDomain(owner, name)
 }
 
 func UpdateDomain(ctx context.Context, id string, domain *Domain) (bool, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	oldDomain, err := getDomain(owner, name)
 	if err != nil {
 		return false, err
@@ -326,7 +326,7 @@ func subDomainPermissions(domain *Domain) ([]*Permission, error) {
 
 // GetAncestorDomains returns a list of domains that contain the given domainIds
 func GetAncestorDomains(ctx context.Context, domainIds ...string) ([]*Domain, error) {
-	owner, _ := util.GetOwnerAndNameFromIdNoCheck(domainIds[0])
+	owner, _ := util.SplitIdIntoOrgAndNameNoError(domainIds[0])
 
 	allDomains, err := GetDomains(ctx, owner)
 	if err != nil {

--- a/object/domain.go
+++ b/object/domain.go
@@ -247,7 +247,7 @@ func domainChangeTrigger(oldName string, newName string) error {
 
 	for _, role := range roles {
 		for j, u := range role.Domains {
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -270,7 +270,7 @@ func domainChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}

--- a/object/enforcer.go
+++ b/object/enforcer.go
@@ -77,7 +77,7 @@ func getEnforcer(owner string, name string) (*Enforcer, error) {
 }
 
 func GetEnforcer(id string) (*Enforcer, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func GetEnforcer(id string) (*Enforcer, error) {
 }
 
 func UpdateEnforcer(id string, enforcer *Enforcer) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/enforcer.go
+++ b/object/enforcer.go
@@ -77,7 +77,7 @@ func getEnforcer(owner string, name string) (*Enforcer, error) {
 }
 
 func GetEnforcer(id string) (*Enforcer, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func GetEnforcer(id string) (*Enforcer, error) {
 }
 
 func UpdateEnforcer(id string, enforcer *Enforcer) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/group.go
+++ b/object/group.go
@@ -262,7 +262,7 @@ func GetAncestorGroups(groupIds ...string) ([]*Group, error) {
 		return nil, nil
 	}
 
-	owner, _ := util.GetOwnerAndNameFromIdNoCheck(groupIds[0])
+	owner, _ := util.SplitIdIntoOrgAndNameNoError(groupIds[0])
 
 	allGroups, err := GetGroups(owner)
 	if err != nil {

--- a/object/group.go
+++ b/object/group.go
@@ -90,7 +90,7 @@ func getGroup(owner string, name string) (*Group, error) {
 }
 
 func GetGroup(id string) (*Group, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func GetGroup(id string) (*Group, error) {
 }
 
 func UpdateGroup(id string, group *Group) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err == nil {
 		return false, err
 	}
@@ -297,7 +297,7 @@ func makeAncestorGroupsTreeMap(groups []*Group) map[string]*TreeNode[*Group] {
 }
 
 func GetGroupUserCount(groupId string, field, value string) (int64, error) {
-	owner, _, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
+	owner, _, err := util.SplitIdIntoOrgAndName(groupId)
 	if err != nil {
 		return 0, err
 	}
@@ -318,7 +318,7 @@ func GetGroupUserCount(groupId string, field, value string) (int64, error) {
 
 func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, sortField, sortOrder string) ([]*User, error) {
 	users := []*User{}
-	owner, _, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
+	owner, _, err := util.SplitIdIntoOrgAndName(groupId)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func getGroupsInGroup(groupId string) ([]*Group, error) {
 }
 
 func getGroupsByParentGroup(groupId string) ([]*Group, error) {
-	owner, parentName, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
+	owner, parentName, err := util.SplitIdIntoOrgAndName(groupId)
 	if err != nil {
 		return nil, err
 	}

--- a/object/group.go
+++ b/object/group.go
@@ -99,7 +99,7 @@ func GetGroup(id string) (*Group, error) {
 
 func UpdateGroup(id string, group *Group) (bool, error) {
 	owner, name, err := util.SplitIdIntoOrgAndName(id)
-	if err == nil {
+	if err != nil {
 		return false, err
 	}
 	oldGroup, err := getGroup(owner, name)

--- a/object/group.go
+++ b/object/group.go
@@ -90,7 +90,7 @@ func getGroup(owner string, name string) (*Group, error) {
 }
 
 func GetGroup(id string) (*Group, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ func GetGroup(id string) (*Group, error) {
 }
 
 func UpdateGroup(id string, group *Group) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
-	if err != nil {
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	if err == nil {
 		return false, err
 	}
 	oldGroup, err := getGroup(owner, name)
@@ -297,7 +297,7 @@ func makeAncestorGroupsTreeMap(groups []*Group) map[string]*TreeNode[*Group] {
 }
 
 func GetGroupUserCount(groupId string, field, value string) (int64, error) {
-	owner, _, err := util.GetOwnerAndNameFromId(groupId)
+	owner, _, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
 	if err != nil {
 		return 0, err
 	}
@@ -318,7 +318,7 @@ func GetGroupUserCount(groupId string, field, value string) (int64, error) {
 
 func GetPaginationGroupUsers(groupId string, offset, limit int, field, value, sortField, sortOrder string) ([]*User, error) {
 	users := []*User{}
-	owner, _, err := util.GetOwnerAndNameFromId(groupId)
+	owner, _, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func getGroupsInGroup(groupId string) ([]*Group, error) {
 }
 
 func getGroupsByParentGroup(groupId string) ([]*Group, error) {
-	owner, parentName, err := util.GetOwnerAndNameFromId(groupId)
+	owner, parentName, err := util.GetOwnerAndNameFromUsernameWithOrg(groupId)
 	if err != nil {
 		return nil, err
 	}

--- a/object/init.go
+++ b/object/init.go
@@ -161,7 +161,7 @@ func initBuiltInUser(ctx context.Context) {
 		IsAdmin:           true,
 		IsForbidden:       false,
 		IsDeleted:         false,
-		SignupApplication: "app-built-in",
+		SignupApplication: CasdoorApplication,
 		CreatedIp:         "127.0.0.1",
 		Properties:        make(map[string]string),
 		MappingStrategy:   "all",
@@ -173,7 +173,7 @@ func initBuiltInUser(ctx context.Context) {
 }
 
 func initBuiltInApplication(ctx context.Context) {
-	application, err := getApplication(ctx, "admin", "app-built-in", nil)
+	application, err := getApplication(ctx, "admin", CasdoorApplication, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -184,7 +184,7 @@ func initBuiltInApplication(ctx context.Context) {
 
 	application = &Application{
 		Owner:                "admin",
-		Name:                 "app-built-in",
+		Name:                 CasdoorApplication,
 		CreatedTime:          util.GetCurrentTime(),
 		DisplayName:          "Casdoor",
 		Logo:                 fmt.Sprintf("%s/img/cg_logo.png", conf.GetConfigString("staticBaseUrl")),
@@ -421,7 +421,7 @@ func initBuiltInPermission() {
 		Domains:      []string{},
 		Model:        "model-built-in",
 		ResourceType: "Application",
-		Resources:    []string{"app-built-in"},
+		Resources:    []string{CasdoorApplication},
 		Actions:      []string{"Read", "Write", "Admin"},
 		Effect:       "Allow",
 		IsEnabled:    true,

--- a/object/migrator_1_240_0_PR_1539.go
+++ b/object/migrator_1_240_0_PR_1539.go
@@ -75,7 +75,7 @@ func (*Migrator_1_240_0_PR_1539) DoMigration() *migrate.Migration {
 			for _, oldSession := range oldSessions {
 				newApplication := "null"
 				if oldSession.Owner == "built-in" {
-					newApplication = "app-built-in"
+					newApplication = CasdoorApplication
 				}
 				newSessions = append(newSessions, &Session{
 					Owner:       oldSession.Owner,

--- a/object/model.go
+++ b/object/model.go
@@ -71,7 +71,7 @@ func getModel(owner string, name string) (*Model, error) {
 }
 
 func GetModel(id string) (*Model, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func UpdateModelWithCheck(id string, modelObj *Model) error {
 }
 
 func UpdateModel(id string, modelObj *Model) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/model.go
+++ b/object/model.go
@@ -71,7 +71,7 @@ func getModel(owner string, name string) (*Model, error) {
 }
 
 func GetModel(id string) (*Model, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func UpdateModelWithCheck(id string, modelObj *Model) error {
 }
 
 func UpdateModel(id string, modelObj *Model) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/organization.go
+++ b/object/organization.go
@@ -126,7 +126,7 @@ func getOrganization(owner string, name string) (*Organization, error) {
 }
 
 func GetOrganization(id string) (*Organization, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func GetMaskedOrganizations(organizations []*Organization, errs ...error) ([]*Or
 func UpdateOrganization(ctx context.Context, id string, organization *Organization, lang string) (bool, error) {
 	var affected int64
 	err := trm.WithTx(ctx, func(ctx context.Context) error {
-		owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+		owner, name, err := util.SplitIdIntoOrgAndName(id)
 		if err != nil {
 			return err
 		}
@@ -390,7 +390,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, role := range roles {
 		for i, u := range role.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -400,7 +400,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, u := range role.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -410,7 +410,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, g := range role.Groups {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(g)
+			owner, name, err := util.SplitIdIntoOrgAndName(g)
 			if err != nil {
 				return err
 			}
@@ -420,7 +420,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, d := range role.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(d)
+			owner, name, err := util.SplitIdIntoOrgAndName(d)
 			if err != nil {
 				return err
 			}
@@ -444,7 +444,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, permission := range permissions {
 		for i, u := range permission.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -454,7 +454,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, u := range permission.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -464,7 +464,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, g := range permission.Groups {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(g)
+			owner, name, err := util.SplitIdIntoOrgAndName(g)
 			if err != nil {
 				return err
 			}
@@ -474,7 +474,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, d := range permission.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(d)
+			owner, name, err := util.SplitIdIntoOrgAndName(d)
 			if err != nil {
 				return err
 			}
@@ -497,7 +497,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, domain := range domains {
 		for i, u := range domain.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}

--- a/object/organization.go
+++ b/object/organization.go
@@ -126,7 +126,7 @@ func getOrganization(owner string, name string) (*Organization, error) {
 }
 
 func GetOrganization(id string) (*Organization, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func GetMaskedOrganizations(organizations []*Organization, errs ...error) ([]*Or
 func UpdateOrganization(ctx context.Context, id string, organization *Organization, lang string) (bool, error) {
 	var affected int64
 	err := trm.WithTx(ctx, func(ctx context.Context) error {
-		owner, name, err := util.GetOwnerAndNameFromId(id)
+		owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 		if err != nil {
 			return err
 		}
@@ -390,7 +390,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, role := range roles {
 		for i, u := range role.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -400,7 +400,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, u := range role.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -410,7 +410,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, g := range role.Groups {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(g)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(g)
 			if err != nil {
 				return err
 			}
@@ -420,7 +420,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, d := range role.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(d)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(d)
 			if err != nil {
 				return err
 			}
@@ -444,7 +444,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, permission := range permissions {
 		for i, u := range permission.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -454,7 +454,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, u := range permission.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -464,7 +464,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, g := range permission.Groups {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(g)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(g)
 			if err != nil {
 				return err
 			}
@@ -474,7 +474,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 		}
 		for i, d := range permission.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(d)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(d)
 			if err != nil {
 				return err
 			}
@@ -497,7 +497,7 @@ func organizationChangeTrigger(ctx context.Context, oldName string, newName stri
 	for _, domain := range domains {
 		for i, u := range domain.Domains {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}

--- a/object/permission.go
+++ b/object/permission.go
@@ -109,12 +109,12 @@ func getPermission(owner string, name string) (*Permission, error) {
 }
 
 func GetPermission(id string) (*Permission, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	return getPermission(owner, name)
 }
 
 func UpdatePermission(id string, permission *Permission) (bool, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	oldPermission, err := getPermission(owner, name)
 	if oldPermission == nil {
 		return false, nil

--- a/object/permission.go
+++ b/object/permission.go
@@ -385,12 +385,12 @@ func (p *Permission) GetId() string {
 }
 
 func (p *Permission) isUserHit(name string) (bool, error) {
-	targetOrg, _, err := util.GetOwnerAndNameFromUsernameWithOrg(name)
+	targetOrg, _, err := util.SplitIdIntoOrgAndName(name)
 	if err != nil {
 		return false, err
 	}
 	for _, user := range p.Users {
-		userOrg, userName, err := util.GetOwnerAndNameFromUsernameWithOrg(user)
+		userOrg, userName, err := util.SplitIdIntoOrgAndName(user)
 		if err != nil {
 			return false, err
 		}

--- a/object/permission.go
+++ b/object/permission.go
@@ -385,12 +385,12 @@ func (p *Permission) GetId() string {
 }
 
 func (p *Permission) isUserHit(name string) (bool, error) {
-	targetOrg, _, err := util.GetOwnerAndNameFromId(name)
+	targetOrg, _, err := util.GetOwnerAndNameFromUsernameWithOrg(name)
 	if err != nil {
 		return false, err
 	}
 	for _, user := range p.Users {
-		userOrg, userName, err := util.GetOwnerAndNameFromId(user)
+		userOrg, userName, err := util.GetOwnerAndNameFromUsernameWithOrg(user)
 		if err != nil {
 			return false, err
 		}

--- a/object/provider.go
+++ b/object/provider.go
@@ -202,7 +202,7 @@ func getProvider(owner string, name string) (*Provider, error) {
 }
 
 func GetProvider(id string) (*Provider, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func GetWechatMiniProgramProvider(application *Application) *Provider {
 }
 
 func UpdateProvider(ctx context.Context, id string, provider *Provider) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}
@@ -296,7 +296,7 @@ func (p *Provider) GetId() string {
 }
 
 func GetCaptchaProviderByOwnerName(applicationId, lang string) (*Provider, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(applicationId)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(applicationId)
 	if err != nil {
 		return nil, err
 	}

--- a/object/provider.go
+++ b/object/provider.go
@@ -202,7 +202,7 @@ func getProvider(owner string, name string) (*Provider, error) {
 }
 
 func GetProvider(id string) (*Provider, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func GetWechatMiniProgramProvider(application *Application) *Provider {
 }
 
 func UpdateProvider(ctx context.Context, id string, provider *Provider) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}
@@ -296,7 +296,7 @@ func (p *Provider) GetId() string {
 }
 
 func GetCaptchaProviderByOwnerName(applicationId, lang string) (*Provider, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(applicationId)
+	owner, name, err := util.SplitIdIntoOrgAndName(applicationId)
 	if err != nil {
 		return nil, err
 	}

--- a/object/radius.go
+++ b/object/radius.go
@@ -73,7 +73,7 @@ func AddRadiusAccounting(ra *RadiusAccounting) error {
 }
 
 func UpdateRadiusAccounting(id string, ra *RadiusAccounting) error {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return err
 	}

--- a/object/radius.go
+++ b/object/radius.go
@@ -73,7 +73,7 @@ func AddRadiusAccounting(ra *RadiusAccounting) error {
 }
 
 func UpdateRadiusAccounting(id string, ra *RadiusAccounting) error {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return err
 	}

--- a/object/resource.go
+++ b/object/resource.go
@@ -16,8 +16,9 @@ package object
 
 import (
 	"fmt"
-	"github.com/casdoor/casdoor/orm"
 	"strings"
+
+	"github.com/casdoor/casdoor/orm"
 
 	"github.com/casdoor/casdoor/util"
 	"github.com/xorm-io/core"
@@ -96,12 +97,12 @@ func getResource(owner string, name string) (*Resource, error) {
 }
 
 func GetResource(id string) (*Resource, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	return getResource(owner, name)
 }
 
 func UpdateResource(id string, resource *Resource) (bool, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	if r, err := getResource(owner, name); err != nil {
 		return false, err
 	} else if r == nil {

--- a/object/role.go
+++ b/object/role.go
@@ -117,7 +117,7 @@ func getRole(owner string, name string) (*Role, error) {
 }
 
 func GetRole(id string) (*Role, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("invalid role id: %s", id))
 	}
@@ -370,7 +370,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 
 	for _, role := range roles {
 		for j, u := range role.Roles {
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -398,7 +398,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -427,7 +427,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, provider := range providers {
 		for j, u := range provider.RoleMappingItems {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u.Role)
+			owner, name, err := util.SplitIdIntoOrgAndName(u.Role)
 			if err != nil {
 				return err
 			}
@@ -456,7 +456,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, ldap := range ldaps {
 		for j, u := range ldap.RoleMappingItems {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u.Role)
+			owner, name, err := util.SplitIdIntoOrgAndName(u.Role)
 			if err != nil {
 				return err
 			}

--- a/object/role.go
+++ b/object/role.go
@@ -65,7 +65,7 @@ func GetRolesByIds(roleIds []string) ([]*Role, error) {
 
 	condBuilder := builder.NewCond()
 	for _, roleId := range roleIds {
-		owner, name := util.GetOwnerAndNameFromIdNoCheck(roleId)
+		owner, name := util.SplitIdIntoOrgAndNameNoError(roleId)
 		condBuilder = condBuilder.Or(builder.Eq{"owner": owner, "name": name})
 	}
 	roles := []*Role{}
@@ -126,7 +126,7 @@ func GetRole(id string) (*Role, error) {
 }
 
 func UpdateRole(id string, role *Role) (bool, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	oldRole, err := getRole(owner, name)
 	if err != nil {
 		return false, err
@@ -493,7 +493,7 @@ func GetAncestorRoles(roleIds ...string) ([]*Role, error) {
 		return nil, nil
 	}
 
-	owner, _ := util.GetOwnerAndNameFromIdNoCheck(roleIds[0])
+	owner, _ := util.SplitIdIntoOrgAndNameNoError(roleIds[0])
 
 	allRoles, err := GetRoles(owner)
 	if err != nil {

--- a/object/role.go
+++ b/object/role.go
@@ -117,7 +117,7 @@ func getRole(owner string, name string) (*Role, error) {
 }
 
 func GetRole(id string) (*Role, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("invalid role id: %s", id))
 	}
@@ -370,7 +370,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 
 	for _, role := range roles {
 		for j, u := range role.Roles {
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -398,7 +398,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Roles {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -427,7 +427,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, provider := range providers {
 		for j, u := range provider.RoleMappingItems {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u.Role)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u.Role)
 			if err != nil {
 				return err
 			}
@@ -456,7 +456,7 @@ func roleChangeTrigger(oldName string, newName string) error {
 	for _, ldap := range ldaps {
 		for j, u := range ldap.RoleMappingItems {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u.Role)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u.Role)
 			if err != nil {
 				return err
 			}

--- a/object/session.go
+++ b/object/session.go
@@ -24,7 +24,7 @@ import (
 	"github.com/xorm-io/core"
 )
 
-var (
+const (
 	CasdoorApplication  = "app-built-in"
 	CasdoorOrganization = "built-in"
 )

--- a/object/session.go
+++ b/object/session.go
@@ -17,6 +17,7 @@ package object
 import (
 	"context"
 	"fmt"
+
 	"github.com/casdoor/casdoor/orm"
 
 	"github.com/beego/beego"
@@ -70,7 +71,7 @@ func GetSessionCount(owner, field, value string) (int64, error) {
 }
 
 func GetSingleSession(id string) (*Session, error) {
-	owner, name, application := util.GetOwnerAndNameAndOtherFromId(id)
+	owner, name, application := util.SplitSessionIdIntoOrgNameAndApp(id)
 	session := Session{Owner: owner, Name: name, Application: application}
 	get, err := orm.AppOrmer.Engine.Get(&session)
 	if err != nil {
@@ -85,7 +86,7 @@ func GetSingleSession(id string) (*Session, error) {
 }
 
 func UpdateSession(id string, session *Session) (bool, error) {
-	owner, name, application := util.GetOwnerAndNameAndOtherFromId(id)
+	owner, name, application := util.SplitSessionIdIntoOrgNameAndApp(id)
 
 	if ss, err := GetSingleSession(id); err != nil {
 		return false, err
@@ -140,7 +141,7 @@ func AddSession(session *Session) (bool, error) {
 }
 
 func DeleteSession(ctx context.Context, id string) (bool, error) {
-	owner, name, applicationName := util.GetOwnerAndNameAndOtherFromId(id)
+	owner, name, applicationName := util.SplitSessionIdIntoOrgNameAndApp(id)
 
 	application, err := GetApplication(ctx, util.GetId("admin", applicationName))
 	if err != nil {
@@ -175,7 +176,7 @@ func DeleteSessionId(ctx context.Context, id string, sessionId string) (bool, er
 		return false, nil
 	}
 
-	owner, _, application := util.GetOwnerAndNameAndOtherFromId(id)
+	owner, _, application := util.SplitSessionIdIntoOrgNameAndApp(id)
 	if owner == CasdoorOrganization && application == CasdoorApplication {
 		DeleteBeegoSession([]string{sessionId})
 	}

--- a/object/token.go
+++ b/object/token.go
@@ -149,7 +149,7 @@ func updateUsedByCode(token *Token) bool {
 }
 
 func GetToken(id string) (*Token, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (token *Token) GetId() string {
 }
 
 func UpdateToken(id string, token *Token) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/token.go
+++ b/object/token.go
@@ -149,7 +149,7 @@ func updateUsedByCode(token *Token) bool {
 }
 
 func GetToken(id string) (*Token, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (token *Token) GetId() string {
 }
 
 func UpdateToken(id string, token *Token) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/user.go
+++ b/object/user.go
@@ -476,7 +476,7 @@ func GetUserByUserID(owner string, userId string) (*User, error) {
 }
 
 func GetUser(id string) (*User, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func updateUser(id string, user *User, columns []string) (int64, error) {
 
 func UpdateUserForAllFields(id string, user *User) (bool, error) {
 	var err error
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}
@@ -943,7 +943,7 @@ func userChangeTrigger(oldName string, newName string) error {
 	for _, role := range roles {
 		for j, u := range role.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}
@@ -965,7 +965,7 @@ func userChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromId(u)
+			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
 			if err != nil {
 				return err
 			}

--- a/object/user.go
+++ b/object/user.go
@@ -476,7 +476,7 @@ func GetUserByUserID(owner string, userId string) (*User, error) {
 }
 
 func GetUser(id string) (*User, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func updateUser(id string, user *User, columns []string) (int64, error) {
 
 func UpdateUserForAllFields(id string, user *User) (bool, error) {
 	var err error
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}
@@ -943,7 +943,7 @@ func userChangeTrigger(oldName string, newName string) error {
 	for _, role := range roles {
 		for j, u := range role.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}
@@ -965,7 +965,7 @@ func userChangeTrigger(oldName string, newName string) error {
 	for _, permission := range permissions {
 		for j, u := range permission.Users {
 			// u = organization/username
-			owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(u)
+			owner, name, err := util.SplitIdIntoOrgAndName(u)
 			if err != nil {
 				return err
 			}

--- a/object/user.go
+++ b/object/user.go
@@ -535,7 +535,7 @@ func GetMaskedUsers(users []*User, errs ...error) ([]*User, error) {
 
 func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, error) {
 	var err error
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	oldUser, err := getUser(owner, name)
 	if err != nil {
 		return false, err
@@ -611,7 +611,7 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 }
 
 func updateUser(id string, user *User, columns []string) (int64, error) {
-	owner, name := util.GetOwnerAndNameFromIdNoCheck(id)
+	owner, name := util.SplitIdIntoOrgAndNameNoError(id)
 	err := user.UpdateUserHash()
 	if err != nil {
 		return 0, err

--- a/object/user_enforcer.go
+++ b/object/user_enforcer.go
@@ -116,7 +116,7 @@ func (e *UserGroupEnforcer) GetUserNamesByGroupName(groupName string) ([]string,
 
 	names := []string{}
 	for _, userId := range userIds {
-		_, name := util.GetOwnerAndNameFromIdNoCheck(userId)
+		_, name := util.SplitIdIntoOrgAndNameNoError(userId)
 		names = append(names, name)
 	}
 

--- a/object/webhook.go
+++ b/object/webhook.go
@@ -85,7 +85,7 @@ func getWebhook(owner string, name string) (*Webhook, error) {
 }
 
 func GetWebhook(id string) (*Webhook, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func GetWebhook(id string) (*Webhook, error) {
 }
 
 func UpdateWebhook(id string, webhook *Webhook) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromId(id)
+	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
 	if err != nil {
 		return false, err
 	}

--- a/object/webhook.go
+++ b/object/webhook.go
@@ -85,7 +85,7 @@ func getWebhook(owner string, name string) (*Webhook, error) {
 }
 
 func GetWebhook(id string) (*Webhook, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func GetWebhook(id string) (*Webhook, error) {
 }
 
 func UpdateWebhook(id string, webhook *Webhook) (bool, error) {
-	owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(id)
+	owner, name, err := util.SplitIdIntoOrgAndName(id)
 	if err != nil {
 		return false, err
 	}

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -80,7 +80,7 @@ func AutoSigninFilter(ctx *context.Context) {
 	userId = ctx.Input.Query("username")
 	password := ctx.Input.Query("password")
 	if userId != "" && password != "" && ctx.Input.Query("grant_type") == "" {
-		owner, name, err := util.GetOwnerAndNameFromId(userId)
+		owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(userId)
 		if err != nil {
 			msg := object.CheckPassErrorToMessage(err, "en")
 			responseError(ctx, msg, http.StatusForbidden)

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -80,7 +80,7 @@ func AutoSigninFilter(ctx *context.Context) {
 	userId = ctx.Input.Query("username")
 	password := ctx.Input.Query("password")
 	if userId != "" && password != "" && ctx.Input.Query("grant_type") == "" {
-		owner, name, err := util.GetOwnerAndNameFromUsernameWithOrg(userId)
+		owner, name, err := util.SplitIdIntoOrgAndName(userId)
 		if err != nil {
 			msg := object.CheckPassErrorToMessage(err, "en")
 			responseError(ctx, msg, http.StatusForbidden)

--- a/routers/record.go
+++ b/routers/record.go
@@ -99,7 +99,7 @@ func defaultRecordLog(ctx *beeCtx.Context) *object.Record {
 	}
 
 	if userId != "" {
-		record.Organization, record.User = util.GetOwnerAndNameFromIdWithPanic(userId)
+		record.Organization, record.User = util.SplitIdIntoOrgAndNameWithPanic(userId)
 	}
 
 	return record

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -86,7 +86,7 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 		return "", nil
 	}
 
-	owner, err := util.GetOwnerFromId(userId)
+	owner, _,  err := util.SplitIdIntoOrgAndName(userId)
 	if err != nil {
 		return "", err
 	}

--- a/util/string.go
+++ b/util/string.go
@@ -78,14 +78,15 @@ func CamelToSnakeCase(camel string) string {
 	return strings.ReplaceAll(buf.String(), " ", "")
 }
 
-func GetOwnerAndNameFromIdWithPanic(id string) (string, string) {
+func SplitIdIntoOrgAndNameWithPanic(id string) (string, string) {
 	tokens := strings.Split(id, "/")
 	if len(tokens) != 2 {
-		panic(errors.New("GetOwnerAndNameFromIdWithPanic() error, wrong token count for ID: " + id))
+		panic(errors.New("SplitIdIntoOrgAndNameWithPanic() error, wrong token count for ID: " + id))
 	}
 
 	return tokens[0], tokens[1]
 }
+
 // SplitIdIntoOrgAndName this func is used not only for users id but for other entity ids too, (roleOwner/roleName = roleId etc .. )
 func SplitIdIntoOrgAndName(id string) (string, string, error) {
 	tokens := strings.Split(id, "/")
@@ -96,24 +97,15 @@ func SplitIdIntoOrgAndName(id string) (string, string, error) {
 	return tokens[0], tokens[1], nil
 }
 
-func GetOwnerFromId(id string) (string, error) {
-	tokens := strings.Split(id, "/")
-	if len(tokens) != 2 {
-		return "", errors.New("GetOwnerFromId() error, wrong token count for ID: " + id)
-	}
-
-	return tokens[0], nil
-}
-
-func GetOwnerAndNameFromIdNoCheck(id string) (string, string) {
+func SplitIdIntoOrgAndNameNoError(id string) (string, string) {
 	tokens := strings.SplitN(id, "/", 2)
 	return tokens[0], tokens[1]
 }
 
-func GetOwnerAndNameAndOtherFromId(id string) (string, string, string) {
+func SplitSessionIdIntoOrgNameAndApp(id string) (string, string, string) {
 	tokens := strings.Split(id, "/")
 	if len(tokens) != 3 {
-		panic(errors.New("GetOwnerAndNameAndOtherFromId() error, wrong token count for ID: " + id))
+		panic(errors.New("SplitIdIntoOrgNameAndApp() error, wrong token count for ID: " + id))
 	}
 
 	return tokens[0], tokens[1], tokens[2]

--- a/util/string.go
+++ b/util/string.go
@@ -86,11 +86,11 @@ func GetOwnerAndNameFromIdWithPanic(id string) (string, string) {
 
 	return tokens[0], tokens[1]
 }
-
-func GetOwnerAndNameFromUsernameWithOrg(id string) (string, string, error) {
+// SplitIdIntoOrgAndName this func is used not only for users id but for other entity ids too, (roleOwner/roleName = roleId etc .. )
+func SplitIdIntoOrgAndName(id string) (string, string, error) {
 	tokens := strings.Split(id, "/")
 	if len(tokens) != 2 {
-		return "", "", errors.New("GetOwnerAndNameFromId() error, wrong token count for ID: " + id)
+		return "", "", errors.New("SplitIdIntoOrgAndName() error, wrong token count for ID: " + id)
 	}
 
 	return tokens[0], tokens[1], nil

--- a/util/string.go
+++ b/util/string.go
@@ -87,7 +87,7 @@ func GetOwnerAndNameFromIdWithPanic(id string) (string, string) {
 	return tokens[0], tokens[1]
 }
 
-func GetOwnerAndNameFromId(id string) (string, string, error) {
+func GetOwnerAndNameFromUsernameWithOrg(id string) (string, string, error) {
 	tokens := strings.Split(id, "/")
 	if len(tokens) != 2 {
 		return "", "", errors.New("GetOwnerAndNameFromId() error, wrong token count for ID: " + id)


### PR DESCRIPTION
fix: rename method for clarity

Moved application detection higher up

Renamed method, added const usage 

resulting log message
```{"dt":"2024-09-02 14:38:26.304","lvl":"INFO","msg":"","obj":"admin/admin-ui-app","ip":"::1: ","obj-type":"application","usr":"PT/fry","act":"logout","r":"success"}```