### PR TITLE
fix: remove invalid usage of go-ldap lib api, that caused panic

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -806,7 +806,6 @@ func (c *ApiController) TestLdapConnection() {
 		c.ResponseError(err.Error())
 		return
 	}
-	connection.Conn.Start()
 
 	err = connection.Conn.Bind(ldap.Username, ldap.Password)
 	if err != nil {


### PR DESCRIPTION
chore: some renaming for clarity
fix: remove invalid usage of go-ldap lib api, that caused panic

ASP-1304

Same issue as https://github.com/go-ldap/ldap/issues/363