### PR TITLE
fix: test ldap connection validation

### DIFF
--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -779,9 +779,15 @@ func (c *ApiController) TestLdapConnection() {
 
 	var ldap ldap_sync.Ldap
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &ldap)
-	if err != nil || util.IsStringsEmpty(ldap.Owner, ldap.Host, ldap.Username, ldap.Password, ldap.BaseDn) {
+	if err != nil || util.IsStringsEmpty(ldap.Owner, ldap.Host, ldap.BaseDn) {
 		c.ResponseError(c.T("general:Missing parameter"))
 		return
+	}
+	if !(ldap.EnableCryptographicAuth && ldap.EnableSsl) {
+		if util.IsStringsEmpty(ldap.Username, ldap.Password) {
+			c.ResponseError(c.T("general:Missing parameter"))
+			return
+		}
 	}
 
 	if ldap.Password == "***" {
@@ -802,12 +808,6 @@ func (c *ApiController) TestLdapConnection() {
 
 	var connection *ldap_sync.LdapConn
 	connection, err = ldap_sync.GetLdapConn(c.Ctx.Request.Context(), &ldap)
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
-	}
-
-	err = connection.Conn.Bind(ldap.Username, ldap.Password)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return


### PR DESCRIPTION
There are 2 ways to connect to ldap - 1) with username and password 2) with certificates

Validation now does not require password in second case.
Bind() call removed, because it is done within GetLdapConn already
Some renaming.