### PR TITLE
fix: check for characters instead of bytes in casbin policy values

### DIFF
--- a/object/domain.go
+++ b/object/domain.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"unicode/utf8"
 
 	"github.com/casdoor/casdoor/orm"
 
@@ -94,7 +95,7 @@ func UpdateDomain(ctx context.Context, id string, domain *Domain) (bool, error) 
 		return false, err
 	}
 
-	if len(domain.GetId()) > policyMaxValueLength {
+	if utf8.RuneCountInString(domain.GetId()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 
@@ -163,7 +164,7 @@ func AddDomain(domain *Domain) (bool, error) {
 		return false, fmt.Errorf("domain %s is in the child domain of %s", id, id)
 	}
 
-	if len(domain.GetId()) > policyMaxValueLength {
+	if utf8.RuneCountInString(domain.GetId()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 

--- a/object/group.go
+++ b/object/group.go
@@ -17,6 +17,7 @@ package object
 import (
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/casdoor/casdoor/orm"
 
@@ -98,7 +99,7 @@ func GetGroup(id string) (*Group, error) {
 }
 
 func UpdateGroup(id string, group *Group) (bool, error) {
-	if len(group.GetId()) > policyMaxValueLength {
+	if utf8.RuneCountInString(group.GetId()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 
@@ -149,7 +150,7 @@ func UpdateGroup(id string, group *Group) (bool, error) {
 }
 
 func AddGroup(group *Group) (bool, error) {
-	if len(group.GetId()) > policyMaxValueLength {
+	if utf8.RuneCountInString(group.GetId()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 

--- a/object/permission.go
+++ b/object/permission.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/casdoor/casdoor/orm"
 
@@ -168,13 +169,13 @@ func AddPermission(permission *Permission) (bool, error) {
 
 func checkPermissionForPolicyMaxValueLength(permission *Permission) error {
 	for _, action := range permission.Actions {
-		if len(action) > policyMaxValueLength {
+		if utf8.RuneCountInString(action) > policyMaxValueLength {
 			return fmt.Errorf("action value %s too long for policies", action)
 		}
 	}
 
 	for _, resource := range permission.Resources {
-		if len(resource) > policyMaxValueLength {
+		if utf8.RuneCountInString(resource) > policyMaxValueLength {
 			return fmt.Errorf("resource value %s too long for policies", resource)
 		}
 	}

--- a/object/role.go
+++ b/object/role.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/casdoor/casdoor/ldap_sync"
 	"github.com/casdoor/casdoor/orm"
@@ -133,7 +134,7 @@ func UpdateRole(id string, role *Role) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(role.GetId()) > policyMaxValueLength {
+	if utf8.RuneCountInString(role.GetId()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 	oldRole, err := getRole(owner, name)
@@ -206,7 +207,7 @@ func AddRole(role *Role) (bool, error) {
 		return false, fmt.Errorf("role %s is in the child roles of %s", id, id)
 	}
 
-	if len(id) > policyMaxValueLength {
+	if utf8.RuneCountInString(id) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 

--- a/object/user.go
+++ b/object/user.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/casdoor/casdoor/orm"
 	"github.com/google/uuid"
@@ -547,7 +548,7 @@ func UpdateUser(id string, user *User, columns []string, isAdmin bool) (bool, er
 		return false, nil
 	}
 
-	if len(user.GetOwnerAndName()) > policyMaxValueLength {
+	if utf8.RuneCountInString(user.GetOwnerAndName()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 
@@ -759,7 +760,7 @@ func AddUser(ctx context.Context, user *User) (bool, error) {
 		user.Id = util.GenerateId()
 	}
 
-	if len(user.GetOwnerAndName()) > policyMaxValueLength {
+	if utf8.RuneCountInString(user.GetOwnerAndName()) > policyMaxValueLength {
 		return false, fmt.Errorf("id too long for policies")
 	}
 


### PR DESCRIPTION
> SQL defines two primary character types: character varying(n) and character(n), where n is a positive integer. Both of these types can store strings up to n characters (not bytes) in length


https://www.postgresql.org/docs/current/datatype-character.html